### PR TITLE
docs: clarify worktree workflow and branch protection in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ ddogctl is a modern CLI for the Datadog API. Like Dogshell, but better. Rich ter
 
 ```bash
 # Setup
-uv sync --all-extras
+uv sync --all-extras                          # --all-extras required for dev tools
 
 # Run tests
 uv run pytest tests/ -v
@@ -68,10 +68,8 @@ Standard test pattern: patch `get_datadog_client` to return `mock_client`, invok
 
 ## Development Workflow
 
-- **Worktrees**: Always create a Git worktree for every new feature, fix, or change. Use `git worktree add .worktrees/<type>/<name> -b <type>/<name>`.
+- **Worktrees**: Always create a Git worktree for every new feature, fix, or change. Use the `./.worktrees` folder. Use `git gtr` instead of plain `git worktree` commands.
 - **Pull requests**: Every change lands via PR — no direct commits to `main`. Open a PR from the worktree branch, get it reviewed, then merge.
-- **Branch protection**: `main` is protected — direct pushes are rejected. Always use a branch + PR.
-- **Cleanup after merge**: Pull main, remove the worktree (`git worktree remove`), delete local and remote branch.
 - **Commits**: Follow conventional commit format.
 
 ## Development Methodology


### PR DESCRIPTION
### **User description**
## Summary
- Use plain `git worktree` commands instead of `git gtr`
- Document that `main` has branch protection (no direct pushes)
- Add cleanup steps after merge (remove worktree, delete branches)

## Test plan
- [x] CLAUDE.md renders correctly


___

### **PR Type**
Documentation


___

### **Description**
- Replace `git gtr` alias with explicit `git worktree add` command

- Add branch protection note for `main` branch

- Document cleanup steps after merge completion


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Development Workflow"] --> B["Use plain git worktree commands"]
  A --> C["Document branch protection on main"]
  A --> D["Add post-merge cleanup steps"]
  B --> E["git worktree add .worktrees/type/name"]
  C --> F["No direct pushes allowed"]
  D --> G["Remove worktree and branches"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Update worktree commands and document branch protection</code>&nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

<ul><li>Replaced <code>git gtr</code> alias reference with explicit <code>git worktree add </code><br><code>.worktrees/<type>/<name> -b <type>/<name></code> command<br> <li> Added new bullet point documenting that <code>main</code> branch is protected <br>against direct pushes<br> <li> Added new bullet point with cleanup instructions: pull main, remove <br>worktree, delete local and remote branches<br> <li> Maintained existing PR and conventional commit guidelines</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/9/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

