### PR TITLE
chore: migrate CI workflow from pip to uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,22 +14,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: true
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: uv sync --all-extras
 
       - name: Check formatting
-        run: black --check ddogctl/ tests/
+        run: uv run black --check ddogctl/ tests/
 
       - name: Lint
-        run: ruff check ddogctl/ tests/
+        run: uv run ruff check ddogctl/ tests/
 
       - name: Test
-        run: pytest tests/ -v --cov=ddogctl --cov-report=xml
+        run: uv run pytest tests/ -v --cov=ddogctl --cov-report=xml
 
   publish:
     runs-on: ubuntu-latest
@@ -40,16 +41,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
 
-      - name: Install build tools
-        run: pip install build
-
       - name: Build package
-        run: python -m build
+        run: uv build
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
### **User description**
## Summary
- Replace `actions/setup-python` + `pip install` with `astral-sh/setup-uv@v7` + `uv sync`
- All commands now use `uv run` prefix (black, ruff, pytest)
- Publish job uses `uv build` instead of `pip install build` + `python -m build`
- Enable uv dependency caching for faster CI runs

## Test plan
- [ ] CI passes on all Python versions (3.10, 3.11, 3.12, 3.13)
- [ ] Verify caching works on subsequent runs


___

### **PR Type**
Enhancement


___

### **Description**
- Replace pip with uv for dependency management in CI workflow

- Enable uv caching for faster CI runs across Python versions

- Simplify build process using uv build instead of pip

- Use uv run prefix for all tool invocations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["setup-python + pip"] -->|"migrate to"| B["setup-uv + uv sync"]
  C["pip install build + python -m build"] -->|"replace with"| D["uv build"]
  E["black, ruff, pytest"] -->|"prefix with uv run"| F["uv run commands"]
  B -->|"enable"| G["dependency caching"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Migrate CI from pip to uv package manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Replaced <code>actions/setup-python@v5</code> with <code>astral-sh/setup-uv@v7</code> for Python <br>setup<br> <li> Changed dependency installation from <code>pip install -e ".[dev]"</code> to <code>uv </code><br><code>sync --all-extras</code><br> <li> Added <code>enable-cache: true</code> to uv setup for faster CI runs<br> <li> Prefixed all tool commands (black, ruff, pytest) with <code>uv run</code><br> <li> Simplified publish job to use <code>uv build</code> instead of separate pip install <br>and python -m build steps</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/10/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+10/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

