### PR TITLE
feat(tag): add tag management commands

### DIFF
--- a/ddogctl/cli.py
+++ b/ddogctl/cli.py
@@ -38,6 +38,7 @@ from ddogctl.commands.logs import logs
 from ddogctl.commands.dbm import dbm
 from ddogctl.commands.investigate import investigate
 from ddogctl.commands.service_check import service_check
+from ddogctl.commands.tag import tag
 
 main.add_command(monitor)
 main.add_command(metric)
@@ -48,6 +49,7 @@ main.add_command(logs)
 main.add_command(dbm)
 main.add_command(investigate)
 main.add_command(service_check)
+main.add_command(tag)
 
 
 if __name__ == "__main__":

--- a/ddogctl/commands/tag.py
+++ b/ddogctl/commands/tag.py
@@ -1,0 +1,136 @@
+"""Tag management commands."""
+
+import click
+import json
+from rich.console import Console
+from rich.table import Table
+from datadog_api_client.v1.model.host_tags import HostTags
+from ddogctl.client import get_datadog_client
+from ddogctl.utils.error import handle_api_error
+
+console = Console()
+
+
+@click.group()
+def tag():
+    """Tag management commands."""
+    pass
+
+
+@tag.command(name="list")
+@click.argument("host")
+@click.option("--source", help="Filter by tag source (e.g., users, chef, puppet)")
+@click.option(
+    "--format", "fmt", type=click.Choice(["json", "table"]), default="table", help="Output format"
+)
+@handle_api_error
+def list_tags(host, source, fmt):
+    """List tags for a host."""
+    client = get_datadog_client()
+
+    kwargs = {"host_name": host}
+    if source:
+        kwargs["source"] = source
+
+    with console.status(f"[cyan]Fetching tags for {host}...[/cyan]"):
+        response = client.tags.get_host_tags(**kwargs)
+
+    tags = getattr(response, "tags", None) or []
+
+    if fmt == "json":
+        output = {"host": host, "tags": tags}
+        print(json.dumps(output, indent=2))
+    else:
+        if not tags:
+            console.print(f"[dim]No tags found for {host}[/dim]")
+            return
+
+        table = Table(title=f"Tags for {host}")
+        table.add_column("Tag", style="cyan")
+
+        for t in sorted(tags):
+            table.add_row(t)
+
+        console.print(table)
+        console.print(f"\n[dim]Total tags: {len(tags)}[/dim]")
+
+
+@tag.command(name="add")
+@click.argument("host")
+@click.argument("tags", nargs=-1, required=True)
+@click.option("--source", help="Tag source (e.g., users, chef, puppet)")
+@handle_api_error
+def add_tags(host, tags, source):
+    """Add tags to a host.
+
+    Appends new tags to the existing tag list. If no source is specified,
+    defaults to "users".
+    """
+    client = get_datadog_client()
+
+    kwargs = {
+        "host_name": host,
+        "body": HostTags(tags=list(tags)),
+    }
+    if source:
+        kwargs["source"] = source
+
+    with console.status(f"[cyan]Adding tags to {host}...[/cyan]"):
+        response = client.tags.create_host_tags(**kwargs)
+
+    result_tags = getattr(response, "tags", None) or []
+    console.print(f"[green]Added {len(list(tags))} tag(s) to {host}[/green]")
+    for t in result_tags:
+        console.print(f"  [cyan]{t}[/cyan]")
+
+
+@tag.command(name="replace")
+@click.argument("host")
+@click.argument("tags", nargs=-1, required=True)
+@click.option("--source", help="Tag source (e.g., users, chef, puppet)")
+@handle_api_error
+def replace_tags(host, tags, source):
+    """Replace all tags on a host.
+
+    Overwrites all tags in the specified source with the supplied tags.
+    If no source is specified, defaults to "users".
+    """
+    client = get_datadog_client()
+
+    kwargs = {
+        "host_name": host,
+        "body": HostTags(tags=list(tags)),
+    }
+    if source:
+        kwargs["source"] = source
+
+    with console.status(f"[cyan]Replacing tags on {host}...[/cyan]"):
+        response = client.tags.update_host_tags(**kwargs)
+
+    result_tags = getattr(response, "tags", None) or []
+    console.print(f"[green]Replaced tags on {host} ({len(result_tags)} tag(s))[/green]")
+    for t in result_tags:
+        console.print(f"  [cyan]{t}[/cyan]")
+
+
+@tag.command(name="detach")
+@click.argument("host")
+@click.option("--source", help="Tag source to detach (e.g., users, chef, puppet)")
+@handle_api_error
+def detach_tags(host, source):
+    """Detach (remove) all tags from a host.
+
+    Removes all tags for a single host. If no source is specified,
+    only deletes from the source "users".
+    """
+    client = get_datadog_client()
+
+    kwargs = {"host_name": host}
+    if source:
+        kwargs["source"] = source
+
+    with console.status(f"[cyan]Detaching tags from {host}...[/cyan]"):
+        client.tags.delete_host_tags(**kwargs)
+
+    source_msg = f" (source: {source})" if source else ""
+    console.print(f"[green]Detached all tags from {host}{source_msg}[/green]")

--- a/tests/commands/test_tag.py
+++ b/tests/commands/test_tag.py
@@ -1,0 +1,298 @@
+"""Tests for tag management commands."""
+
+import json
+from unittest.mock import Mock, patch
+
+
+def test_tag_list_table_format(mock_client, runner):
+    """Test listing tags for a host in table format."""
+    from ddogctl.commands.tag import tag
+
+    mock_response = Mock()
+    mock_response.host = "web-prod-01"
+    mock_response.tags = ["env:prod", "service:web", "team:platform"]
+    mock_client.tags.get_host_tags.return_value = mock_response
+
+    with patch("ddogctl.commands.tag.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(tag, ["list", "web-prod-01"])
+
+    assert result.exit_code == 0
+    assert "web-prod-01" in result.output
+    assert "env:prod" in result.output
+    assert "service:web" in result.output
+    assert "team:platform" in result.output
+
+
+def test_tag_list_json_format(mock_client, runner):
+    """Test listing tags for a host in JSON format."""
+    from ddogctl.commands.tag import tag
+
+    mock_response = Mock()
+    mock_response.host = "web-prod-01"
+    mock_response.tags = ["env:prod", "service:web"]
+    mock_client.tags.get_host_tags.return_value = mock_response
+
+    with patch("ddogctl.commands.tag.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(tag, ["list", "web-prod-01", "--format", "json"])
+
+    assert result.exit_code == 0
+    output = json.loads(result.output)
+    assert output["host"] == "web-prod-01"
+    assert "env:prod" in output["tags"]
+    assert "service:web" in output["tags"]
+
+
+def test_tag_list_with_source(mock_client, runner):
+    """Test listing tags filtered by source."""
+    from ddogctl.commands.tag import tag
+
+    mock_response = Mock()
+    mock_response.host = "web-prod-01"
+    mock_response.tags = ["env:prod"]
+    mock_client.tags.get_host_tags.return_value = mock_response
+
+    with patch("ddogctl.commands.tag.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(tag, ["list", "web-prod-01", "--source", "users"])
+
+    assert result.exit_code == 0
+    mock_client.tags.get_host_tags.assert_called_once_with(host_name="web-prod-01", source="users")
+
+
+def test_tag_list_without_source(mock_client, runner):
+    """Test listing tags without source does not pass source kwarg."""
+    from ddogctl.commands.tag import tag
+
+    mock_response = Mock()
+    mock_response.host = "web-prod-01"
+    mock_response.tags = ["env:prod"]
+    mock_client.tags.get_host_tags.return_value = mock_response
+
+    with patch("ddogctl.commands.tag.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(tag, ["list", "web-prod-01"])
+
+    assert result.exit_code == 0
+    mock_client.tags.get_host_tags.assert_called_once_with(host_name="web-prod-01")
+
+
+def test_tag_list_empty_tags(mock_client, runner):
+    """Test listing tags when host has no tags."""
+    from ddogctl.commands.tag import tag
+
+    mock_response = Mock()
+    mock_response.host = "web-prod-01"
+    mock_response.tags = []
+    mock_client.tags.get_host_tags.return_value = mock_response
+
+    with patch("ddogctl.commands.tag.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(tag, ["list", "web-prod-01"])
+
+    assert result.exit_code == 0
+    assert "No tags" in result.output
+
+
+def test_tag_list_no_tags_attribute(mock_client, runner):
+    """Test listing tags when response has no tags attribute (unset)."""
+    from ddogctl.commands.tag import tag
+
+    mock_response = Mock(spec=[])
+    mock_response.host = "web-prod-01"
+    # Simulate tags being unset by making hasattr return False
+    mock_client.tags.get_host_tags.return_value = mock_response
+
+    with patch("ddogctl.commands.tag.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(tag, ["list", "web-prod-01"])
+
+    assert result.exit_code == 0
+    assert "No tags" in result.output
+
+
+def test_tag_add_single_tag(mock_client, runner):
+    """Test adding a single tag to a host."""
+    from ddogctl.commands.tag import tag
+
+    mock_response = Mock()
+    mock_response.host = "web-prod-01"
+    mock_response.tags = ["env:prod"]
+    mock_client.tags.create_host_tags.return_value = mock_response
+
+    with patch("ddogctl.commands.tag.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(tag, ["add", "web-prod-01", "env:prod"])
+
+    assert result.exit_code == 0
+    assert "Added" in result.output or "added" in result.output
+    mock_client.tags.create_host_tags.assert_called_once()
+    call_kwargs = mock_client.tags.create_host_tags.call_args
+    assert call_kwargs.kwargs["host_name"] == "web-prod-01"
+    body = call_kwargs.kwargs["body"]
+    assert body.tags == ["env:prod"]
+
+
+def test_tag_add_multiple_tags(mock_client, runner):
+    """Test adding multiple tags to a host."""
+    from ddogctl.commands.tag import tag
+
+    mock_response = Mock()
+    mock_response.host = "web-prod-01"
+    mock_response.tags = ["env:prod", "service:web", "team:platform"]
+    mock_client.tags.create_host_tags.return_value = mock_response
+
+    with patch("ddogctl.commands.tag.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            tag, ["add", "web-prod-01", "env:prod", "service:web", "team:platform"]
+        )
+
+    assert result.exit_code == 0
+    call_kwargs = mock_client.tags.create_host_tags.call_args
+    body = call_kwargs.kwargs["body"]
+    assert sorted(body.tags) == sorted(["env:prod", "service:web", "team:platform"])
+
+
+def test_tag_add_with_source(mock_client, runner):
+    """Test adding tags with a specific source."""
+    from ddogctl.commands.tag import tag
+
+    mock_response = Mock()
+    mock_response.host = "web-prod-01"
+    mock_response.tags = ["env:prod"]
+    mock_client.tags.create_host_tags.return_value = mock_response
+
+    with patch("ddogctl.commands.tag.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(tag, ["add", "web-prod-01", "env:prod", "--source", "chef"])
+
+    assert result.exit_code == 0
+    call_kwargs = mock_client.tags.create_host_tags.call_args
+    assert call_kwargs.kwargs["source"] == "chef"
+
+
+def test_tag_add_without_source(mock_client, runner):
+    """Test adding tags without source does not pass source kwarg."""
+    from ddogctl.commands.tag import tag
+
+    mock_response = Mock()
+    mock_response.host = "web-prod-01"
+    mock_response.tags = ["env:prod"]
+    mock_client.tags.create_host_tags.return_value = mock_response
+
+    with patch("ddogctl.commands.tag.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(tag, ["add", "web-prod-01", "env:prod"])
+
+    assert result.exit_code == 0
+    call_kwargs = mock_client.tags.create_host_tags.call_args
+    assert "source" not in call_kwargs.kwargs
+
+
+def test_tag_replace_tags(mock_client, runner):
+    """Test replacing all tags on a host."""
+    from ddogctl.commands.tag import tag
+
+    mock_response = Mock()
+    mock_response.host = "web-prod-01"
+    mock_response.tags = ["env:staging"]
+    mock_client.tags.update_host_tags.return_value = mock_response
+
+    with patch("ddogctl.commands.tag.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(tag, ["replace", "web-prod-01", "env:staging"])
+
+    assert result.exit_code == 0
+    assert "Replaced" in result.output or "replaced" in result.output
+    mock_client.tags.update_host_tags.assert_called_once()
+    call_kwargs = mock_client.tags.update_host_tags.call_args
+    assert call_kwargs.kwargs["host_name"] == "web-prod-01"
+    body = call_kwargs.kwargs["body"]
+    assert body.tags == ["env:staging"]
+
+
+def test_tag_replace_multiple_tags(mock_client, runner):
+    """Test replacing tags with multiple new tags."""
+    from ddogctl.commands.tag import tag
+
+    mock_response = Mock()
+    mock_response.host = "web-prod-01"
+    mock_response.tags = ["env:staging", "service:api"]
+    mock_client.tags.update_host_tags.return_value = mock_response
+
+    with patch("ddogctl.commands.tag.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(tag, ["replace", "web-prod-01", "env:staging", "service:api"])
+
+    assert result.exit_code == 0
+    call_kwargs = mock_client.tags.update_host_tags.call_args
+    body = call_kwargs.kwargs["body"]
+    assert sorted(body.tags) == sorted(["env:staging", "service:api"])
+
+
+def test_tag_replace_with_source(mock_client, runner):
+    """Test replacing tags with a specific source."""
+    from ddogctl.commands.tag import tag
+
+    mock_response = Mock()
+    mock_response.host = "web-prod-01"
+    mock_response.tags = ["env:staging"]
+    mock_client.tags.update_host_tags.return_value = mock_response
+
+    with patch("ddogctl.commands.tag.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(tag, ["replace", "web-prod-01", "env:staging", "--source", "puppet"])
+
+    assert result.exit_code == 0
+    call_kwargs = mock_client.tags.update_host_tags.call_args
+    assert call_kwargs.kwargs["source"] == "puppet"
+
+
+def test_tag_detach(mock_client, runner):
+    """Test detaching (removing) all tags from a host."""
+    from ddogctl.commands.tag import tag
+
+    mock_client.tags.delete_host_tags.return_value = None
+
+    with patch("ddogctl.commands.tag.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(tag, ["detach", "web-prod-01"])
+
+    assert result.exit_code == 0
+    assert "Detached" in result.output or "detached" in result.output or "Removed" in result.output
+    mock_client.tags.delete_host_tags.assert_called_once_with(host_name="web-prod-01")
+
+
+def test_tag_detach_with_source(mock_client, runner):
+    """Test detaching tags with a specific source."""
+    from ddogctl.commands.tag import tag
+
+    mock_client.tags.delete_host_tags.return_value = None
+
+    with patch("ddogctl.commands.tag.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(tag, ["detach", "web-prod-01", "--source", "users"])
+
+    assert result.exit_code == 0
+    mock_client.tags.delete_host_tags.assert_called_once_with(
+        host_name="web-prod-01", source="users"
+    )
+
+
+def test_tag_add_requires_tags_argument(runner):
+    """Test that add command requires at least one tag."""
+    from ddogctl.commands.tag import tag
+
+    result = runner.invoke(tag, ["add", "web-prod-01"])
+    assert result.exit_code != 0
+
+
+def test_tag_replace_requires_tags_argument(runner):
+    """Test that replace command requires at least one tag."""
+    from ddogctl.commands.tag import tag
+
+    result = runner.invoke(tag, ["replace", "web-prod-01"])
+    assert result.exit_code != 0
+
+
+def test_tag_list_table_shows_total(mock_client, runner):
+    """Test that table output shows tag count."""
+    from ddogctl.commands.tag import tag
+
+    mock_response = Mock()
+    mock_response.host = "web-prod-01"
+    mock_response.tags = ["env:prod", "service:web", "team:platform"]
+    mock_client.tags.get_host_tags.return_value = mock_response
+
+    with patch("ddogctl.commands.tag.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(tag, ["list", "web-prod-01"])
+
+    assert result.exit_code == 0
+    assert "3" in result.output


### PR DESCRIPTION
### **User description**
## Summary
- Add `tag list <host>` with `--source` filtering and `--format json|table` output
- Add `tag add <host> <tags...>` to append tags to a host
- Add `tag replace <host> <tags...>` to overwrite all tags on a host
- Add `tag detach <host>` to remove all tags from a host

Part of Phase 1.5 - Tag Management.

## Test plan
- [x] Tests for list with table and json output
- [x] Tests for list with --source filter
- [x] Tests for list with empty/no tags
- [x] Tests for add single and multiple tags
- [x] Tests for add with and without --source
- [x] Tests for replace with single and multiple tags
- [x] Tests for replace with --source
- [x] Tests for detach with and without --source
- [x] Tests for required tags argument on add/replace
- [x] All 283 existing tests still pass
- [x] black, ruff, mypy clean (mypy errors are pre-existing in config.py)


___

### **PR Type**
Enhancement


___

### **Description**
- Add tag management commands (list, add, replace, detach)

- Implement shared utility modules for Phase 1 infrastructure

- Support source filtering and JSON/table output formats

- Include comprehensive test coverage for all utilities


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["CLI Entry Point"]
  TagCmd["Tag Commands Module"]
  Utils["Shared Utilities"]
  API["Datadog API Client"]
  
  CLI -- "imports tag command" --> TagCmd
  TagCmd -- "list/add/replace/detach" --> API
  TagCmd -- "uses confirm/export/file_input" --> Utils
  Utils -- "confirmation/JSON handling" --> TagCmd
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>cli.py</strong><dd><code>Register tag command with CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/13/files#diff-1ca1a58dd47b18afff9b729ec6430c335581acb24899da2e49951588191ea17e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tag.py</strong><dd><code>Implement tag management commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/13/files#diff-65a61699132fd7c8e5d9d5da8d000c4328703e25420be78cabe1721a485c4907">+136/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>confirm.py</strong><dd><code>Add confirmation prompt utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/13/files#diff-fa99d8450d24bf35aa5c9d430b2cb907bd3ad717d97aa29244ef0b274e4fbce3">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>export.py</strong><dd><code>Add JSON export utility with directory creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/13/files#diff-210963fba7706daa1afb10e27d7ba5f6fdaff4248069ed7cae10c5669b546404">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>file_input.py</strong><dd><code>Add JSON file parsing Click callback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/13/files#diff-eba0134be9d0ee1223bca2b89d9d20180f8af1042025f5ae7de5cb67395a9185">+53/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>test_tag.py</strong><dd><code>Comprehensive tests for tag commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/13/files#diff-c653c823d73312c69614fd5c6ffd9e5edf14efdb4ccbb780652f456fef113939">+298/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_confirm.py</strong><dd><code>Tests for confirmation utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/13/files#diff-817eebdb52e252394fddd790953a2217c0d5aa8c612916c4a1ea4c6d54e26064">+56/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_export.py</strong><dd><code>Tests for JSON export utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/13/files#diff-12e00ac4a3d784ae464dd14a4e983dd52e8d14d38d4dfa48d20a7509b5d63237">+74/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_file_input.py</strong><dd><code>Tests for JSON file input parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/13/files#diff-4debc6d19d91f207e100f3d6c135a48dca93d4fed4293b279746b21e9d8646be">+84/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/13/files#diff-e83d4ce58211688fdd3f132906c3c4ff02b28e14a069c7516df75eeb2478a904">[link]</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

