### PR TITLE
feat(monitor): add create, update, delete, mute-all, unmute-all commands

### DIFF
--- a/ddogctl/client.py
+++ b/ddogctl/client.py
@@ -9,6 +9,7 @@ from datadog_api_client.v1.api import (
     hosts_api,
     tags_api,
     service_checks_api,
+    downtimes_api,
 )
 from datadog_api_client.v2.api import logs_api, spans_api, service_definition_api
 from ddogctl.config import DatadogConfig
@@ -36,6 +37,7 @@ class DatadogClient:
         self.hosts = hosts_api.HostsApi(self.api_client)
         self.tags = tags_api.TagsApi(self.api_client)
         self.service_checks = service_checks_api.ServiceChecksApi(self.api_client)
+        self.downtimes = downtimes_api.DowntimesApi(self.api_client)
 
         # V2 APIs
         self.logs = logs_api.LogsApi(self.api_client)

--- a/tests/commands/test_monitor.py
+++ b/tests/commands/test_monitor.py
@@ -1,5 +1,6 @@
 """Tests for monitor commands."""
 
+import json
 import pytest
 from unittest.mock import Mock, patch
 from click.testing import CliRunner
@@ -425,3 +426,421 @@ def test_monitor_workflow_list_get(mock_client, runner):
         monitor_details = json.loads(result.output)
         assert monitor_details["id"] == 1
         assert monitor_details["name"] == "Monitor A"
+
+
+# ============================================================================
+# Monitor Create Command Tests
+# ============================================================================
+
+
+def test_monitor_create_with_inline_flags(mock_client, runner):
+    """Test creating a monitor with inline flags."""
+    created_monitor = MockMonitor(100, "CPU Alert", MonitorOverallStates.OK)
+    mock_client.monitors.create_monitor.return_value = created_monitor
+
+    with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            monitor,
+            [
+                "create",
+                "--type",
+                "metric alert",
+                "--query",
+                "avg:system.cpu.user{*} > 80",
+                "--name",
+                "CPU Alert",
+                "--message",
+                "CPU is high",
+                "--tags",
+                "env:prod,service:web",
+                "--priority",
+                "3",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Monitor 100 created" in result.output
+        mock_client.monitors.create_monitor.assert_called_once()
+
+        # Verify the Monitor body was passed correctly
+        call_kwargs = mock_client.monitors.create_monitor.call_args
+        body = call_kwargs[1]["body"] if "body" in call_kwargs[1] else call_kwargs[0][0]
+        assert str(body.type) == "metric alert"
+        assert body.query == "avg:system.cpu.user{*} > 80"
+        assert body.name == "CPU Alert"
+        assert body.message == "CPU is high"
+        assert body.tags == ["env:prod", "service:web"]
+        assert body.priority == 3
+
+
+def test_monitor_create_with_minimal_flags(mock_client, runner):
+    """Test creating a monitor with only required flags."""
+    created_monitor = MockMonitor(101, "Test", MonitorOverallStates.OK)
+    mock_client.monitors.create_monitor.return_value = created_monitor
+
+    with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            monitor,
+            [
+                "create",
+                "--type",
+                "metric alert",
+                "--query",
+                "avg:system.cpu.user{*} > 80",
+                "--name",
+                "Test",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Monitor 101 created" in result.output
+        mock_client.monitors.create_monitor.assert_called_once()
+
+
+def test_monitor_create_missing_required_flags(mock_client, runner):
+    """Test that create fails when required flags are missing."""
+    with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+        # Missing --type
+        result = runner.invoke(
+            monitor,
+            ["create", "--query", "avg:system.cpu.user{*} > 80", "--name", "Test"],
+        )
+        assert result.exit_code != 0
+
+        # Missing --query
+        result = runner.invoke(
+            monitor,
+            ["create", "--type", "metric alert", "--name", "Test"],
+        )
+        assert result.exit_code != 0
+
+        # Missing --name
+        result = runner.invoke(
+            monitor,
+            ["create", "--type", "metric alert", "--query", "avg:system.cpu.user{*} > 80"],
+        )
+        assert result.exit_code != 0
+
+
+def test_monitor_create_from_file(mock_client, runner, tmp_path):
+    """Test creating a monitor from a JSON file."""
+    monitor_def = {
+        "type": "metric alert",
+        "query": "avg:system.cpu.user{*} > 90",
+        "name": "High CPU from file",
+        "message": "CPU is very high",
+        "tags": ["env:prod"],
+        "priority": 2,
+    }
+    json_file = tmp_path / "monitor.json"
+    json_file.write_text(json.dumps(monitor_def))
+
+    created_monitor = MockMonitor(102, "High CPU from file", MonitorOverallStates.OK)
+    mock_client.monitors.create_monitor.return_value = created_monitor
+
+    with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(monitor, ["create", "-f", str(json_file)])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Monitor 102 created" in result.output
+        mock_client.monitors.create_monitor.assert_called_once()
+
+
+def test_monitor_create_from_file_overrides_flags(mock_client, runner, tmp_path):
+    """Test that -f flag takes precedence over inline flags."""
+    monitor_def = {
+        "type": "metric alert",
+        "query": "avg:system.mem.used{*} > 90",
+        "name": "Memory from file",
+    }
+    json_file = tmp_path / "monitor.json"
+    json_file.write_text(json.dumps(monitor_def))
+
+    created_monitor = MockMonitor(103, "Memory from file", MonitorOverallStates.OK)
+    mock_client.monitors.create_monitor.return_value = created_monitor
+
+    with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            monitor,
+            [
+                "create",
+                "-f",
+                str(json_file),
+                "--type",
+                "log alert",
+                "--query",
+                "ignored",
+                "--name",
+                "ignored",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        # The file data should be used, not the flags
+        call_kwargs = mock_client.monitors.create_monitor.call_args
+        body = call_kwargs[1]["body"] if "body" in call_kwargs[1] else call_kwargs[0][0]
+        assert body.name == "Memory from file"
+
+
+def test_monitor_create_from_invalid_file(mock_client, runner, tmp_path):
+    """Test creating a monitor from an invalid JSON file."""
+    json_file = tmp_path / "bad.json"
+    json_file.write_text("not valid json {{{")
+
+    with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(monitor, ["create", "-f", str(json_file)])
+
+        assert result.exit_code != 0
+
+
+def test_monitor_create_from_nonexistent_file(mock_client, runner):
+    """Test creating a monitor from a file that doesn't exist."""
+    with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(monitor, ["create", "-f", "/nonexistent/path.json"])
+
+        assert result.exit_code != 0
+
+
+def test_monitor_create_json_output(mock_client, runner):
+    """Test creating a monitor with JSON output format."""
+    created_monitor = MockMonitor(104, "JSON Test", MonitorOverallStates.OK)
+    mock_client.monitors.create_monitor.return_value = created_monitor
+
+    with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            monitor,
+            [
+                "create",
+                "--type",
+                "metric alert",
+                "--query",
+                "avg:system.cpu.user{*} > 80",
+                "--name",
+                "JSON Test",
+                "--format",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["id"] == 104
+        assert output["name"] == "JSON Test"
+
+
+# ============================================================================
+# Monitor Update Command Tests
+# ============================================================================
+
+
+def test_monitor_update_with_inline_flags(mock_client, runner):
+    """Test updating a monitor with inline flags."""
+    updated_monitor = MockMonitor(200, "Updated CPU Alert", MonitorOverallStates.OK)
+    mock_client.monitors.update_monitor.return_value = updated_monitor
+
+    with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            monitor,
+            [
+                "update",
+                "200",
+                "--name",
+                "Updated CPU Alert",
+                "--query",
+                "avg:system.cpu.user{*} > 90",
+                "--message",
+                "Updated message",
+                "--tags",
+                "env:prod,team:sre",
+                "--priority",
+                "1",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Monitor 200 updated" in result.output
+        mock_client.monitors.update_monitor.assert_called_once()
+
+        # Verify monitor_id and body
+        call_args = mock_client.monitors.update_monitor.call_args
+        assert call_args[0][0] == 200  # monitor_id
+
+
+def test_monitor_update_partial_flags(mock_client, runner):
+    """Test updating a monitor with only some flags."""
+    updated_monitor = MockMonitor(201, "Partially Updated", MonitorOverallStates.OK)
+    mock_client.monitors.update_monitor.return_value = updated_monitor
+
+    with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            monitor,
+            ["update", "201", "--name", "Partially Updated"],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Monitor 201 updated" in result.output
+
+
+def test_monitor_update_from_file(mock_client, runner, tmp_path):
+    """Test updating a monitor from a JSON file."""
+    monitor_def = {
+        "name": "Updated from file",
+        "query": "avg:system.mem.used{*} > 95",
+        "tags": ["env:staging"],
+    }
+    json_file = tmp_path / "update.json"
+    json_file.write_text(json.dumps(monitor_def))
+
+    updated_monitor = MockMonitor(202, "Updated from file", MonitorOverallStates.OK)
+    mock_client.monitors.update_monitor.return_value = updated_monitor
+
+    with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(monitor, ["update", "202", "-f", str(json_file)])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Monitor 202 updated" in result.output
+        mock_client.monitors.update_monitor.assert_called_once()
+
+
+def test_monitor_update_json_output(mock_client, runner):
+    """Test updating a monitor with JSON output format."""
+    updated_monitor = MockMonitor(203, "JSON Update", MonitorOverallStates.OK)
+    mock_client.monitors.update_monitor.return_value = updated_monitor
+
+    with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            monitor,
+            ["update", "203", "--name", "JSON Update", "--format", "json"],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["id"] == 203
+
+
+# ============================================================================
+# Monitor Delete Command Tests
+# ============================================================================
+
+
+def test_monitor_delete_with_confirm_flag(mock_client, runner):
+    """Test deleting a monitor with --confirm flag (no prompt)."""
+    mock_client.monitors.delete_monitor.return_value = Mock()
+
+    with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(monitor, ["delete", "300", "--confirm"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Monitor 300 deleted" in result.output
+        mock_client.monitors.delete_monitor.assert_called_once_with(300)
+
+
+def test_monitor_delete_interactive_confirm_yes(mock_client, runner):
+    """Test deleting a monitor with interactive confirmation (user says yes)."""
+    mock_client.monitors.delete_monitor.return_value = Mock()
+
+    with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(monitor, ["delete", "301"], input="y\n")
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Monitor 301 deleted" in result.output
+        mock_client.monitors.delete_monitor.assert_called_once_with(301)
+
+
+def test_monitor_delete_interactive_confirm_no(mock_client, runner):
+    """Test deleting a monitor with interactive confirmation (user says no)."""
+    with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(monitor, ["delete", "302"], input="n\n")
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Aborted" in result.output
+        mock_client.monitors.delete_monitor.assert_not_called()
+
+
+# ============================================================================
+# Monitor Mute-All Command Tests
+# ============================================================================
+
+
+def test_monitor_mute_all(mock_client, runner):
+    """Test muting all monitors by creating a global downtime."""
+    mock_downtime = Mock()
+    mock_downtime.id = 5000
+    mock_client.downtimes = Mock()
+    mock_client.downtimes.create_downtime.return_value = mock_downtime
+
+    with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(monitor, ["mute-all"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "All monitors muted" in result.output
+        mock_client.downtimes.create_downtime.assert_called_once()
+
+        # Verify the downtime scope is "*"
+        call_kwargs = mock_client.downtimes.create_downtime.call_args
+        body = call_kwargs[1]["body"] if "body" in call_kwargs[1] else call_kwargs[0][0]
+        assert body.scope == ["*"]
+
+
+def test_monitor_mute_all_with_message(mock_client, runner):
+    """Test muting all monitors with a custom message."""
+    mock_downtime = Mock()
+    mock_downtime.id = 5001
+    mock_client.downtimes = Mock()
+    mock_client.downtimes.create_downtime.return_value = mock_downtime
+
+    with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(monitor, ["mute-all", "--message", "Maintenance window"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "All monitors muted" in result.output
+
+        call_kwargs = mock_client.downtimes.create_downtime.call_args
+        body = call_kwargs[1]["body"] if "body" in call_kwargs[1] else call_kwargs[0][0]
+        assert body.message == "Maintenance window"
+
+
+# ============================================================================
+# Monitor Unmute-All Command Tests
+# ============================================================================
+
+
+def test_monitor_unmute_all(mock_client, runner):
+    """Test unmuting all monitors by cancelling global downtimes."""
+    mock_downtime_active = Mock()
+    mock_downtime_active.id = 6000
+    mock_downtime_active.scope = ["*"]
+    mock_downtime_active.disabled = False
+
+    mock_downtime_other = Mock()
+    mock_downtime_other.id = 6001
+    mock_downtime_other.scope = ["host:myhost"]
+    mock_downtime_other.disabled = False
+
+    mock_client.downtimes = Mock()
+    mock_client.downtimes.list_downtimes.return_value = [
+        mock_downtime_active,
+        mock_downtime_other,
+    ]
+    mock_client.downtimes.cancel_downtime.return_value = Mock()
+
+    with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(monitor, ["unmute-all"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "All monitors unmuted" in result.output
+        # Should only cancel the global downtime (scope ["*"]), not the host-specific one
+        mock_client.downtimes.cancel_downtime.assert_called_once_with(6000)
+
+
+def test_monitor_unmute_all_no_global_downtimes(mock_client, runner):
+    """Test unmuting when there are no global downtimes."""
+    mock_client.downtimes = Mock()
+    mock_client.downtimes.list_downtimes.return_value = []
+
+    with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(monitor, ["unmute-all"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "No global downtimes found" in result.output
+        mock_client.downtimes.cancel_downtime.assert_not_called()


### PR DESCRIPTION
### **User description**
## Summary
- Add `monitor create` with inline flags and `-f` file input
- Add `monitor update` with inline flags and `-f` file input
- Add `monitor delete` with `--confirm` safety flag and interactive prompt
- Add `monitor mute-all` and `monitor unmute-all` (global downtime management)
- Add `downtimes` API to `DatadogClient`

Part of Phase 1.1 - Monitor CRUD completion.

## Test plan
- [x] Tests for create with inline flags (type, query, name, message, tags, priority)
- [x] Tests for create with minimal required flags
- [x] Tests for create missing required flags
- [x] Tests for create with `-f` file input
- [x] Tests for create file overrides inline flags
- [x] Tests for create with invalid/nonexistent file
- [x] Tests for create with JSON output format
- [x] Tests for update with inline flags
- [x] Tests for update with partial flags
- [x] Tests for update with `-f` file input
- [x] Tests for update with JSON output format
- [x] Tests for delete with `--confirm` flag (no prompt)
- [x] Tests for delete with interactive confirmation (yes/no)
- [x] Tests for mute-all (global downtime creation)
- [x] Tests for mute-all with custom message
- [x] Tests for unmute-all (global downtime cancellation)
- [x] Tests for unmute-all with no global downtimes
- [x] All 18 existing tests still pass (37 total)
- [x] Full suite: 284 tests pass
- [x] black, ruff clean
- [x] mypy clean (pre-existing config.py errors only)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `monitor create` command with inline flags and JSON file input

- Add `monitor update` command with partial field updates

- Add `monitor delete` command with confirmation safety flag

- Add `monitor mute-all` and `monitor unmute-all` for global downtime management

- Integrate downtimes API into DatadogClient for mute operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Monitor Commands"] --> B["Create"]
  A --> C["Update"]
  A --> D["Delete"]
  A --> E["Mute-All"]
  A --> F["Unmute-All"]
  B --> G["Inline Flags / File Input"]
  C --> G
  E --> H["Downtimes API"]
  F --> H
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Add downtimes API to DatadogClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/client.py

<ul><li>Import <code>downtimes_api</code> from datadog_api_client.v1.api<br> <li> Initialize <code>self.downtimes</code> API client in DatadogClient constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/14/files#diff-4e22d74821607a2dc683b1c483fe0aa643ff5dc3aab9f76c1e5b4373c0f6bf57">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>monitor.py</strong><dd><code>Implement full monitor CRUD and downtime operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/commands/monitor.py

<ul><li>Add <code>monitor create</code> command supporting inline flags (--type, --query, <br>--name, --message, --tags, --priority) and -f file input<br> <li> Add <code>monitor update</code> command supporting partial field updates via flags <br>or JSON file<br> <li> Add <code>monitor delete</code> command with --confirm flag and interactive <br>confirmation prompt<br> <li> Add <code>monitor mute-all</code> command to create global downtime (scope: *)<br> <li> Add <code>monitor unmute-all</code> command to cancel all active global downtimes<br> <li> Import utility functions <code>load_json_option</code> and <code>confirm_action</code> for <br>shared functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/14/files#diff-cbca5eefc15920db1240a9f63066e274b6a7fb054f246dbff4ce5af1ebe842e8">+187/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_monitor.py</strong><dd><code>Add comprehensive tests for monitor CRUD operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/commands/test_monitor.py

<ul><li>Add 18 new test cases covering monitor create with inline flags, <br>minimal flags, missing required flags, file input, file override <br>behavior, invalid/nonexistent files, and JSON output<br> <li> Add 5 test cases for monitor update with inline flags, partial <br>updates, file input, and JSON output<br> <li> Add 3 test cases for monitor delete with --confirm flag and <br>interactive yes/no confirmation<br> <li> Add 3 test cases for mute-all and unmute-all commands including global <br>downtime filtering and edge cases</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/14/files#diff-5bf563ba73d25362aa8ca227e780d7428f640156123a0579a18d925dc4b50367">+419/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

