### PR TITLE
feat(downtime): add downtime management commands

### DIFF
--- a/ddogctl/cli.py
+++ b/ddogctl/cli.py
@@ -39,6 +39,7 @@ from ddogctl.commands.dbm import dbm
 from ddogctl.commands.investigate import investigate
 from ddogctl.commands.service_check import service_check
 from ddogctl.commands.tag import tag
+from ddogctl.commands.downtime import downtime
 
 main.add_command(monitor)
 main.add_command(metric)
@@ -50,6 +51,7 @@ main.add_command(dbm)
 main.add_command(investigate)
 main.add_command(service_check)
 main.add_command(tag)
+main.add_command(downtime)
 
 
 if __name__ == "__main__":

--- a/ddogctl/commands/downtime.py
+++ b/ddogctl/commands/downtime.py
@@ -1,0 +1,302 @@
+"""Downtime management commands."""
+
+import re
+import time
+import click
+import json
+from datetime import datetime
+from rich.console import Console
+from rich.table import Table
+from ddogctl.client import get_datadog_client
+from ddogctl.utils.error import handle_api_error
+from ddogctl.utils.file_input import load_json_option
+from ddogctl.utils.confirm import confirm_action
+
+console = Console()
+
+
+def parse_downtime_time(value: str) -> int:
+    """Parse a time string for downtime start/end.
+
+    Supports:
+        - "now" -> current Unix timestamp
+        - Relative offsets: "2h", "30m", "1d" -> current time + offset
+        - ISO datetime strings -> parsed to Unix timestamp
+
+    Args:
+        value: Time string to parse.
+
+    Returns:
+        Unix timestamp as integer.
+
+    Raises:
+        ValueError: If the time string format is not recognized.
+    """
+    if value == "now":
+        return int(time.time())
+
+    # Relative time: e.g. "2h", "30m", "1d"
+    match = re.fullmatch(r"(\d+)([hmd])", value)
+    if match:
+        amount = int(match.group(1))
+        unit = match.group(2)
+        multipliers = {"m": 60, "h": 3600, "d": 86400}
+        return int(time.time()) + amount * multipliers[unit]
+
+    # ISO datetime
+    try:
+        return int(datetime.fromisoformat(value).timestamp())
+    except (ValueError, TypeError):
+        raise ValueError(
+            f"Invalid time format: '{value}'. Use 'now', relative (2h, 30m, 1d), or ISO datetime."
+        )
+
+
+@click.group()
+def downtime():
+    """Downtime management commands."""
+    pass
+
+
+@downtime.command(name="list")
+@click.option("--current-only", is_flag=True, help="Show only currently active downtimes")
+@click.option(
+    "--format", type=click.Choice(["json", "table"]), default="table", help="Output format"
+)
+@handle_api_error
+def list_downtimes(current_only, format):
+    """List all downtimes."""
+    client = get_datadog_client()
+
+    kwargs = {}
+    if current_only:
+        kwargs["current_only"] = True
+
+    with console.status("[cyan]Fetching downtimes...[/cyan]"):
+        downtimes = client.downtimes.list_downtimes(**kwargs)
+
+    if format == "json":
+        print(json.dumps([d.to_dict() for d in downtimes], indent=2, default=str))
+    else:
+        table = Table(title="Downtimes")
+        table.add_column("ID", style="cyan", width=10)
+        table.add_column("Scope", style="white", min_width=20)
+        table.add_column("Message", style="dim", min_width=30)
+        table.add_column("Start", style="yellow", width=20)
+        table.add_column("End", style="yellow", width=20)
+        table.add_column("Disabled", style="red", width=10)
+
+        for d in downtimes:
+            scope_str = ", ".join(d.scope) if d.scope else ""
+            start_str = (
+                datetime.fromtimestamp(d.start).strftime("%Y-%m-%d %H:%M:%S") if d.start else "N/A"
+            )
+            end_str = (
+                datetime.fromtimestamp(d.end).strftime("%Y-%m-%d %H:%M:%S") if d.end else "None"
+            )
+
+            table.add_row(
+                str(d.id),
+                scope_str,
+                d.message or "",
+                start_str,
+                end_str,
+                str(d.disabled),
+            )
+
+        console.print(table)
+        console.print(f"\n[dim]Total downtimes: {len(downtimes)}[/dim]")
+
+
+@downtime.command(name="get")
+@click.argument("downtime_id", type=int)
+@click.option(
+    "--format", type=click.Choice(["json", "table"]), default="table", help="Output format"
+)
+@handle_api_error
+def get_downtime(downtime_id, format):
+    """Get downtime details."""
+    client = get_datadog_client()
+
+    with console.status(f"[cyan]Fetching downtime {downtime_id}...[/cyan]"):
+        dt = client.downtimes.get_downtime(downtime_id)
+
+    if format == "json":
+        print(json.dumps(dt.to_dict(), indent=2, default=str))
+    else:
+        console.print(f"\n[bold cyan]Downtime #{dt.id}[/bold cyan]")
+        scope_str = ", ".join(dt.scope) if dt.scope else "N/A"
+        console.print(f"[bold]Scope:[/bold] {scope_str}")
+
+        if dt.message:
+            console.print(f"[bold]Message:[/bold] {dt.message}")
+
+        start_str = (
+            datetime.fromtimestamp(dt.start).strftime("%Y-%m-%d %H:%M:%S") if dt.start else "N/A"
+        )
+        console.print(f"[bold]Start:[/bold] {start_str}")
+
+        end_str = datetime.fromtimestamp(dt.end).strftime("%Y-%m-%d %H:%M:%S") if dt.end else "None"
+        console.print(f"[bold]End:[/bold] {end_str}")
+        console.print(f"[bold]Disabled:[/bold] {dt.disabled}")
+
+        if dt.monitor_id:
+            console.print(f"[bold]Monitor ID:[/bold] {dt.monitor_id}")
+
+
+@downtime.command(name="create")
+@click.option("--scope", default=None, help="Downtime scope (e.g., 'env:prod')")
+@click.option("--start", "start_time", default=None, help="Start time (now, 2h, ISO datetime)")
+@click.option("--end", "end_time", default=None, help="End time (2h, 30m, 1d, ISO datetime)")
+@click.option("--message", default=None, help="Downtime message")
+@click.option("--monitor-id", type=int, default=None, help="Scope to a specific monitor")
+@click.option(
+    "-f",
+    "--file",
+    "file_data",
+    callback=load_json_option,
+    default=None,
+    help="JSON file with downtime definition",
+)
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["json", "table"]),
+    default="table",
+    help="Output format",
+)
+@handle_api_error
+def create_downtime_cmd(scope, start_time, end_time, message, monitor_id, file_data, fmt):
+    """Create a downtime from inline flags or a JSON file."""
+    from datadog_api_client.v1.model.downtime import Downtime
+
+    if file_data:
+        downtime_body = Downtime(**file_data)
+    else:
+        if not scope:
+            raise click.UsageError("Missing option '--scope' (required without -f)")
+
+        kwargs = {"scope": [scope]}
+
+        if start_time:
+            kwargs["start"] = parse_downtime_time(start_time)
+
+        if end_time:
+            kwargs["end"] = parse_downtime_time(end_time)
+
+        if message:
+            kwargs["message"] = message
+
+        if monitor_id is not None:
+            kwargs["monitor_id"] = monitor_id
+
+        downtime_body = Downtime(**kwargs)
+
+    client = get_datadog_client()
+
+    with console.status("[cyan]Creating downtime...[/cyan]"):
+        result = client.downtimes.create_downtime(body=downtime_body)
+
+    if fmt == "json":
+        print(json.dumps(result.to_dict(), indent=2, default=str))
+    else:
+        console.print(f"[green]Downtime {result.id} created[/green]")
+        scope_str = ", ".join(result.scope) if result.scope else "N/A"
+        console.print(f"[bold]Scope:[/bold] {scope_str}")
+        if result.message:
+            console.print(f"[bold]Message:[/bold] {result.message}")
+
+
+@downtime.command(name="update")
+@click.argument("downtime_id", type=int)
+@click.option("--scope", default=None, help="New scope (e.g., 'env:staging')")
+@click.option("--end", "end_time", default=None, help="New end time (4h, 30m, ISO datetime)")
+@click.option("--message", default=None, help="New message")
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["json", "table"]),
+    default="table",
+    help="Output format",
+)
+@handle_api_error
+def update_downtime_cmd(downtime_id, scope, end_time, message, fmt):
+    """Update a downtime by ID."""
+    from datadog_api_client.v1.model.downtime import Downtime
+
+    kwargs = {}
+    if scope is not None:
+        kwargs["scope"] = [scope]
+    if end_time is not None:
+        kwargs["end"] = parse_downtime_time(end_time)
+    if message is not None:
+        kwargs["message"] = message
+
+    if not kwargs:
+        raise click.UsageError("No update fields specified. Use --scope, --end, or --message.")
+
+    update_body = Downtime(**kwargs)
+    client = get_datadog_client()
+
+    with console.status(f"[cyan]Updating downtime {downtime_id}...[/cyan]"):
+        result = client.downtimes.update_downtime(downtime_id, body=update_body)
+
+    if fmt == "json":
+        print(json.dumps(result.to_dict(), indent=2, default=str))
+    else:
+        console.print(f"[green]Downtime {downtime_id} updated[/green]")
+
+
+@downtime.command(name="delete")
+@click.argument("downtime_id", type=int)
+@click.option("--confirm", "confirmed", is_flag=True, help="Skip confirmation prompt")
+@handle_api_error
+def delete_downtime_cmd(downtime_id, confirmed):
+    """Cancel (delete) a downtime by ID."""
+    if not confirm_action(f"Cancel downtime {downtime_id}?", confirmed):
+        console.print("[yellow]Aborted[/yellow]")
+        return
+
+    client = get_datadog_client()
+
+    with console.status(f"[cyan]Cancelling downtime {downtime_id}...[/cyan]"):
+        client.downtimes.cancel_downtime(downtime_id)
+
+    console.print(f"[green]Downtime {downtime_id} cancelled[/green]")
+
+
+@downtime.command(name="cancel-by-scope")
+@click.argument("scope")
+@click.option("--confirm", "confirmed", is_flag=True, help="Skip confirmation prompt")
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["json", "table"]),
+    default="table",
+    help="Output format",
+)
+@handle_api_error
+def cancel_by_scope_cmd(scope, confirmed, fmt):
+    """Cancel all active downtimes matching a scope (bulk operation)."""
+    from datadog_api_client.v1.model.cancel_downtimes_by_scope_request import (
+        CancelDowntimesByScopeRequest,
+    )
+
+    if not confirm_action(f"Cancel all downtimes with scope '{scope}'?", confirmed):
+        console.print("[yellow]Aborted[/yellow]")
+        return
+
+    client = get_datadog_client()
+
+    body = CancelDowntimesByScopeRequest(scope=scope)
+
+    with console.status(f"[cyan]Cancelling downtimes with scope '{scope}'...[/cyan]"):
+        result = client.downtimes.cancel_downtimes_by_scope(body=body)
+
+    if fmt == "json":
+        print(json.dumps({"cancelled_ids": result.cancelled_ids}, indent=2, default=str))
+    else:
+        count = len(result.cancelled_ids) if result.cancelled_ids else 0
+        console.print(f"[green]{count} downtime(s) cancelled for scope '{scope}'[/green]")
+        if result.cancelled_ids:
+            console.print(f"[dim]IDs: {', '.join(str(i) for i in result.cancelled_ids)}[/dim]")

--- a/tests/commands/test_downtime.py
+++ b/tests/commands/test_downtime.py
@@ -1,0 +1,713 @@
+"""Tests for downtime management commands."""
+
+import json
+import time
+import pytest
+from unittest.mock import Mock, patch
+from click.testing import CliRunner
+from ddogctl.commands.downtime import downtime, parse_downtime_time
+
+# ============================================================================
+# parse_downtime_time Tests
+# ============================================================================
+
+
+class TestParseDowntimeTime:
+    """Tests for the parse_downtime_time helper."""
+
+    def test_now(self):
+        """'now' returns current Unix timestamp."""
+        before = int(time.time())
+        result = parse_downtime_time("now")
+        after = int(time.time())
+        assert before <= result <= after
+
+    def test_relative_hours(self):
+        """Relative hours like '2h' returns current time + offset."""
+        before = int(time.time()) + 2 * 3600
+        result = parse_downtime_time("2h")
+        after = int(time.time()) + 2 * 3600
+        assert before <= result <= after
+
+    def test_relative_minutes(self):
+        """Relative minutes like '30m' returns current time + offset."""
+        before = int(time.time()) + 30 * 60
+        result = parse_downtime_time("30m")
+        after = int(time.time()) + 30 * 60
+        assert before <= result <= after
+
+    def test_relative_days(self):
+        """Relative days like '1d' returns current time + offset."""
+        before = int(time.time()) + 86400
+        result = parse_downtime_time("1d")
+        after = int(time.time()) + 86400
+        assert before <= result <= after
+
+    def test_iso_datetime(self):
+        """ISO datetime string is parsed to Unix timestamp."""
+        result = parse_downtime_time("2025-06-15T10:00:00")
+        from datetime import datetime
+
+        expected = int(datetime.fromisoformat("2025-06-15T10:00:00").timestamp())
+        assert result == expected
+
+    def test_invalid_format_raises(self):
+        """Invalid time format raises ValueError."""
+        with pytest.raises(ValueError):
+            parse_downtime_time("invalid")
+
+
+# ============================================================================
+# Downtime List Command Tests
+# ============================================================================
+
+
+class TestDowntimeList:
+    """Tests for downtime list command."""
+
+    @pytest.fixture
+    def mock_client(self):
+        client = Mock()
+        client.downtimes = Mock()
+        return client
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def _make_downtime(
+        self, id, scope, message="", start=None, end=None, disabled=False, monitor_id=None
+    ):
+        """Create a mock downtime object."""
+        dt = Mock()
+        dt.id = id
+        dt.scope = scope
+        dt.message = message
+        dt.start = start or int(time.time())
+        dt.end = end
+        dt.disabled = disabled
+        dt.monitor_id = monitor_id
+        dt.to_dict = Mock(
+            return_value={
+                "id": id,
+                "scope": scope,
+                "message": message,
+                "start": dt.start,
+                "end": end,
+                "disabled": disabled,
+                "monitor_id": monitor_id,
+            }
+        )
+        return dt
+
+    def test_list_table_format(self, mock_client, runner):
+        """Test listing downtimes in table format."""
+        downtimes = [
+            self._make_downtime(1, ["env:prod"], "Deploy v2.5"),
+            self._make_downtime(2, ["env:staging"], "Testing"),
+        ]
+        mock_client.downtimes.list_downtimes.return_value = downtimes
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(downtime, ["list"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Downtimes" in result.output
+        assert "env:prod" in result.output
+        assert "env:staging" in result.output
+
+    def test_list_json_format(self, mock_client, runner):
+        """Test listing downtimes in JSON format."""
+        downtimes = [
+            self._make_downtime(1, ["env:prod"], "Deploy v2.5"),
+        ]
+        mock_client.downtimes.list_downtimes.return_value = downtimes
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(downtime, ["list", "--format", "json"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert len(output) == 1
+        assert output[0]["id"] == 1
+
+    def test_list_current_only(self, mock_client, runner):
+        """Test listing only currently active downtimes."""
+        downtimes = [
+            self._make_downtime(1, ["env:prod"]),
+        ]
+        mock_client.downtimes.list_downtimes.return_value = downtimes
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(downtime, ["list", "--current-only"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        mock_client.downtimes.list_downtimes.assert_called_once_with(current_only=True)
+
+    def test_list_without_current_only(self, mock_client, runner):
+        """Test listing all downtimes (no current_only flag)."""
+        mock_client.downtimes.list_downtimes.return_value = []
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(downtime, ["list"])
+
+        assert result.exit_code == 0
+        mock_client.downtimes.list_downtimes.assert_called_once_with()
+
+    def test_list_empty(self, mock_client, runner):
+        """Test listing when no downtimes exist."""
+        mock_client.downtimes.list_downtimes.return_value = []
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(downtime, ["list"])
+
+        assert result.exit_code == 0
+        assert "Total downtimes: 0" in result.output
+
+
+# ============================================================================
+# Downtime Get Command Tests
+# ============================================================================
+
+
+class TestDowntimeGet:
+    """Tests for downtime get command."""
+
+    @pytest.fixture
+    def mock_client(self):
+        client = Mock()
+        client.downtimes = Mock()
+        return client
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def test_get_table_format(self, mock_client, runner):
+        """Test getting a downtime in table format."""
+        dt = Mock()
+        dt.id = 123
+        dt.scope = ["env:prod"]
+        dt.message = "Deploying v2.5"
+        dt.start = 1700000000
+        dt.end = 1700007200
+        dt.disabled = False
+        dt.monitor_id = 456
+
+        mock_client.downtimes.get_downtime.return_value = dt
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(downtime, ["get", "123"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Downtime #123" in result.output
+        assert "env:prod" in result.output
+        assert "Deploying v2.5" in result.output
+        mock_client.downtimes.get_downtime.assert_called_once_with(123)
+
+    def test_get_json_format(self, mock_client, runner):
+        """Test getting a downtime in JSON format."""
+        dt = Mock()
+        dt.id = 456
+        dt.scope = ["env:staging"]
+        dt.message = "Testing"
+        dt.start = 1700000000
+        dt.end = None
+        dt.disabled = False
+        dt.monitor_id = None
+        dt.to_dict = Mock(
+            return_value={
+                "id": 456,
+                "scope": ["env:staging"],
+                "message": "Testing",
+                "start": 1700000000,
+                "end": None,
+                "disabled": False,
+                "monitor_id": None,
+            }
+        )
+
+        mock_client.downtimes.get_downtime.return_value = dt
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(downtime, ["get", "456", "--format", "json"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["id"] == 456
+        assert output["scope"] == ["env:staging"]
+
+
+# ============================================================================
+# Downtime Create Command Tests
+# ============================================================================
+
+
+class TestDowntimeCreate:
+    """Tests for downtime create command."""
+
+    @pytest.fixture
+    def mock_client(self):
+        client = Mock()
+        client.downtimes = Mock()
+        return client
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def test_create_with_inline_flags(self, mock_client, runner):
+        """Test creating a downtime with inline flags."""
+        created_dt = Mock()
+        created_dt.id = 100
+        created_dt.scope = ["env:prod"]
+        created_dt.message = "Deploying v2.5"
+        mock_client.downtimes.create_downtime.return_value = created_dt
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                downtime,
+                [
+                    "create",
+                    "--scope",
+                    "env:prod",
+                    "--start",
+                    "now",
+                    "--end",
+                    "2h",
+                    "--message",
+                    "Deploying v2.5",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Downtime 100 created" in result.output
+        mock_client.downtimes.create_downtime.assert_called_once()
+
+    def test_create_with_monitor_id(self, mock_client, runner):
+        """Test creating a downtime scoped to a specific monitor."""
+        created_dt = Mock()
+        created_dt.id = 101
+        created_dt.scope = ["env:prod"]
+        created_dt.message = "Monitor-specific downtime"
+        mock_client.downtimes.create_downtime.return_value = created_dt
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                downtime,
+                [
+                    "create",
+                    "--scope",
+                    "env:prod",
+                    "--start",
+                    "now",
+                    "--end",
+                    "1h",
+                    "--message",
+                    "Monitor-specific downtime",
+                    "--monitor-id",
+                    "789",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Downtime 101 created" in result.output
+
+        # Verify monitor_id was passed
+        call_kwargs = mock_client.downtimes.create_downtime.call_args
+        body = call_kwargs[1]["body"] if "body" in call_kwargs[1] else call_kwargs[0][0]
+        assert body.monitor_id == 789
+
+    def test_create_missing_scope(self, mock_client, runner):
+        """Test that create fails when --scope is missing and no file provided."""
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                downtime,
+                [
+                    "create",
+                    "--start",
+                    "now",
+                    "--end",
+                    "2h",
+                ],
+            )
+
+        assert result.exit_code != 0
+
+    def test_create_from_file(self, mock_client, runner, tmp_path):
+        """Test creating a downtime from a JSON file."""
+        downtime_def = {
+            "scope": ["env:prod"],
+            "start": 1700000000,
+            "end": 1700007200,
+            "message": "From file",
+        }
+        json_file = tmp_path / "downtime.json"
+        json_file.write_text(json.dumps(downtime_def))
+
+        created_dt = Mock()
+        created_dt.id = 102
+        created_dt.scope = ["env:prod"]
+        created_dt.message = "From file"
+        mock_client.downtimes.create_downtime.return_value = created_dt
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(downtime, ["create", "-f", str(json_file)])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Downtime 102 created" in result.output
+        mock_client.downtimes.create_downtime.assert_called_once()
+
+    def test_create_from_file_overrides_flags(self, mock_client, runner, tmp_path):
+        """Test that -f flag takes precedence over inline flags."""
+        downtime_def = {
+            "scope": ["env:staging"],
+            "start": 1700000000,
+            "end": 1700007200,
+            "message": "File wins",
+        }
+        json_file = tmp_path / "downtime.json"
+        json_file.write_text(json.dumps(downtime_def))
+
+        created_dt = Mock()
+        created_dt.id = 103
+        created_dt.scope = ["env:staging"]
+        created_dt.message = "File wins"
+        mock_client.downtimes.create_downtime.return_value = created_dt
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                downtime,
+                [
+                    "create",
+                    "-f",
+                    str(json_file),
+                    "--scope",
+                    "env:prod",
+                    "--message",
+                    "Ignored",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        call_kwargs = mock_client.downtimes.create_downtime.call_args
+        body = call_kwargs[1]["body"] if "body" in call_kwargs[1] else call_kwargs[0][0]
+        assert body.scope == ["env:staging"]
+
+    def test_create_json_output(self, mock_client, runner):
+        """Test creating a downtime with JSON output format."""
+        created_dt = Mock()
+        created_dt.id = 104
+        created_dt.scope = ["env:prod"]
+        created_dt.message = "Deploy"
+        created_dt.to_dict = Mock(
+            return_value={
+                "id": 104,
+                "scope": ["env:prod"],
+                "message": "Deploy",
+            }
+        )
+        mock_client.downtimes.create_downtime.return_value = created_dt
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                downtime,
+                [
+                    "create",
+                    "--scope",
+                    "env:prod",
+                    "--start",
+                    "now",
+                    "--end",
+                    "2h",
+                    "--message",
+                    "Deploy",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["id"] == 104
+
+    def test_create_scope_is_list(self, mock_client, runner):
+        """Test that scope is passed as a list to the API."""
+        created_dt = Mock()
+        created_dt.id = 105
+        created_dt.scope = ["env:prod"]
+        created_dt.message = ""
+        mock_client.downtimes.create_downtime.return_value = created_dt
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                downtime,
+                [
+                    "create",
+                    "--scope",
+                    "env:prod",
+                    "--start",
+                    "now",
+                    "--end",
+                    "1h",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        call_kwargs = mock_client.downtimes.create_downtime.call_args
+        body = call_kwargs[1]["body"] if "body" in call_kwargs[1] else call_kwargs[0][0]
+        assert body.scope == ["env:prod"]
+
+
+# ============================================================================
+# Downtime Update Command Tests
+# ============================================================================
+
+
+class TestDowntimeUpdate:
+    """Tests for downtime update command."""
+
+    @pytest.fixture
+    def mock_client(self):
+        client = Mock()
+        client.downtimes = Mock()
+        return client
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def test_update_end_time(self, mock_client, runner):
+        """Test updating the end time of a downtime."""
+        updated_dt = Mock()
+        updated_dt.id = 200
+        updated_dt.scope = ["env:prod"]
+        updated_dt.message = "Extended maintenance"
+        mock_client.downtimes.update_downtime.return_value = updated_dt
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                downtime,
+                [
+                    "update",
+                    "200",
+                    "--end",
+                    "4h",
+                    "--message",
+                    "Extended maintenance",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Downtime 200 updated" in result.output
+        mock_client.downtimes.update_downtime.assert_called_once()
+
+        # Verify downtime_id was passed correctly
+        call_args = mock_client.downtimes.update_downtime.call_args
+        assert call_args[0][0] == 200
+
+    def test_update_message_only(self, mock_client, runner):
+        """Test updating only the message of a downtime."""
+        updated_dt = Mock()
+        updated_dt.id = 201
+        updated_dt.scope = ["env:prod"]
+        updated_dt.message = "New message"
+        mock_client.downtimes.update_downtime.return_value = updated_dt
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                downtime,
+                [
+                    "update",
+                    "201",
+                    "--message",
+                    "New message",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Downtime 201 updated" in result.output
+
+    def test_update_no_fields_errors(self, mock_client, runner):
+        """Test that update without any fields gives an error."""
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(downtime, ["update", "202"])
+
+        assert result.exit_code != 0
+
+    def test_update_json_output(self, mock_client, runner):
+        """Test updating a downtime with JSON output format."""
+        updated_dt = Mock()
+        updated_dt.id = 203
+        updated_dt.to_dict = Mock(
+            return_value={
+                "id": 203,
+                "scope": ["env:prod"],
+                "message": "Updated",
+            }
+        )
+        mock_client.downtimes.update_downtime.return_value = updated_dt
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                downtime,
+                [
+                    "update",
+                    "203",
+                    "--message",
+                    "Updated",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["id"] == 203
+
+    def test_update_scope(self, mock_client, runner):
+        """Test updating the scope of a downtime."""
+        updated_dt = Mock()
+        updated_dt.id = 204
+        updated_dt.scope = ["env:staging"]
+        updated_dt.message = ""
+        mock_client.downtimes.update_downtime.return_value = updated_dt
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                downtime,
+                [
+                    "update",
+                    "204",
+                    "--scope",
+                    "env:staging",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Downtime 204 updated" in result.output
+
+
+# ============================================================================
+# Downtime Delete Command Tests
+# ============================================================================
+
+
+class TestDowntimeDelete:
+    """Tests for downtime delete command."""
+
+    @pytest.fixture
+    def mock_client(self):
+        client = Mock()
+        client.downtimes = Mock()
+        return client
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def test_delete_with_confirm_flag(self, mock_client, runner):
+        """Test deleting a downtime with --confirm flag (no prompt)."""
+        mock_client.downtimes.cancel_downtime.return_value = None
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(downtime, ["delete", "300", "--confirm"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Downtime 300 cancelled" in result.output
+        mock_client.downtimes.cancel_downtime.assert_called_once_with(300)
+
+    def test_delete_interactive_confirm_yes(self, mock_client, runner):
+        """Test deleting a downtime with interactive confirmation (user says yes)."""
+        mock_client.downtimes.cancel_downtime.return_value = None
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(downtime, ["delete", "301"], input="y\n")
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Downtime 301 cancelled" in result.output
+        mock_client.downtimes.cancel_downtime.assert_called_once_with(301)
+
+    def test_delete_interactive_confirm_no(self, mock_client, runner):
+        """Test deleting a downtime with interactive confirmation (user says no)."""
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(downtime, ["delete", "302"], input="n\n")
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Aborted" in result.output
+        mock_client.downtimes.cancel_downtime.assert_not_called()
+
+
+# ============================================================================
+# Downtime Cancel-by-Scope Command Tests
+# ============================================================================
+
+
+class TestDowntimeCancelByScope:
+    """Tests for downtime cancel-by-scope command."""
+
+    @pytest.fixture
+    def mock_client(self):
+        client = Mock()
+        client.downtimes = Mock()
+        return client
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def test_cancel_by_scope(self, mock_client, runner):
+        """Test cancelling downtimes by scope."""
+        cancel_result = Mock()
+        cancel_result.cancelled_ids = [1, 2, 3]
+        mock_client.downtimes.cancel_downtimes_by_scope.return_value = cancel_result
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(downtime, ["cancel-by-scope", "env:prod", "--confirm"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "cancelled" in result.output.lower()
+        mock_client.downtimes.cancel_downtimes_by_scope.assert_called_once()
+
+    def test_cancel_by_scope_interactive_confirm_yes(self, mock_client, runner):
+        """Test cancel-by-scope with interactive confirmation (user says yes)."""
+        cancel_result = Mock()
+        cancel_result.cancelled_ids = [10]
+        mock_client.downtimes.cancel_downtimes_by_scope.return_value = cancel_result
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(downtime, ["cancel-by-scope", "env:staging"], input="y\n")
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "cancelled" in result.output.lower()
+
+    def test_cancel_by_scope_interactive_confirm_no(self, mock_client, runner):
+        """Test cancel-by-scope with interactive confirmation (user says no)."""
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(downtime, ["cancel-by-scope", "env:prod"], input="n\n")
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Aborted" in result.output
+        mock_client.downtimes.cancel_downtimes_by_scope.assert_not_called()
+
+    def test_cancel_by_scope_json_output(self, mock_client, runner):
+        """Test cancel-by-scope with JSON output."""
+        cancel_result = Mock()
+        cancel_result.cancelled_ids = [5, 6]
+        mock_client.downtimes.cancel_downtimes_by_scope.return_value = cancel_result
+
+        with patch("ddogctl.commands.downtime.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                downtime,
+                [
+                    "cancel-by-scope",
+                    "env:prod",
+                    "--confirm",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["cancelled_ids"] == [5, 6]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ def mock_client():
     client.dbm = Mock()
     client.service_definitions = Mock()
     client.service_checks = Mock()
+    client.downtimes = Mock()
     return client
 
 


### PR DESCRIPTION
### **User description**
## Summary
- Add `downtime` command group with list, get, create, update, delete, and cancel-by-scope subcommands
- Friendly time parsing for --start and --end (relative times like `2h`, `30m`, `1d`, ISO datetimes, and `now`)
- cancel-by-scope bulk operation for scope-based downtime cancellation
- Full TDD test coverage (32 tests) following existing patterns

## Test plan
- [x] All tests pass (`uv run pytest tests/ -v` -- 350 passed)
- [x] Black formatting passes
- [x] Ruff linting passes


___

### **PR Type**
Enhancement


___

### **Description**
- Add comprehensive downtime management command group with six subcommands

- Implement flexible time parsing supporting relative offsets, ISO datetimes, and "now"

- Provide list, get, create, update, delete, and cancel-by-scope operations

- Include full test coverage with 32 tests following TDD patterns


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["CLI Entry Point"] -- "import downtime" --> DT["Downtime Command Group"]
  DT -- "list" --> LIST["List all/current downtimes"]
  DT -- "get" --> GET["Get downtime details"]
  DT -- "create" --> CREATE["Create from flags or JSON file"]
  DT -- "update" --> UPDATE["Update scope/end/message"]
  DT -- "delete" --> DELETE["Cancel single downtime"]
  DT -- "cancel-by-scope" --> BULK["Bulk cancel by scope"]
  CREATE -- "parse_downtime_time" --> PARSE["Parse now/relative/ISO datetime"]
  UPDATE -- "parse_downtime_time" --> PARSE
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.py</strong><dd><code>Register downtime command group with CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/cli.py

<ul><li>Import new <code>downtime</code> command group from <code>ddogctl.commands.downtime</code><br> <li> Register <code>downtime</code> command with main CLI application</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/15/files#diff-1ca1a58dd47b18afff9b729ec6430c335581acb24899da2e49951588191ea17e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>downtime.py</strong><dd><code>Implement complete downtime management command suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/commands/downtime.py

<ul><li>Implement <code>parse_downtime_time()</code> helper supporting "now", relative <br>offsets (2h, 30m, 1d), and ISO datetime strings<br> <li> Add <code>list</code> subcommand with <code>--current-only</code> flag and table/JSON output <br>formats<br> <li> Add <code>get</code> subcommand to retrieve downtime details by ID with table/JSON <br>output<br> <li> Add <code>create</code> subcommand supporting inline flags (--scope, --start, <br>--end, --message, --monitor-id) or JSON file input<br> <li> Add <code>update</code> subcommand to modify scope, end time, or message of <br>existing downtime<br> <li> Add <code>delete</code> subcommand with confirmation prompt for cancelling <br>individual downtimes<br> <li> Add <code>cancel-by-scope</code> bulk operation subcommand with confirmation and <br>JSON/table output</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/15/files#diff-a697bbbdf1174a182f29c323712bea1ce939f1a63162ed74e5977a92c3ef669f">+302/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_downtime.py</strong><dd><code>Add comprehensive test suite for downtime commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/commands/test_downtime.py

<ul><li>Add 6 test classes covering parse_downtime_time, list, get, create, <br>update, delete, and cancel-by-scope commands<br> <li> Test time parsing for "now", relative offsets (hours/minutes/days), <br>ISO datetimes, and invalid formats<br> <li> Test list command with table/JSON formats, current-only filtering, and <br>empty results<br> <li> Test get command with both output formats and API integration<br> <li> Test create command with inline flags, JSON file input, monitor-id <br>scoping, and file precedence over flags<br> <li> Test update command for scope, end time, message fields and validation <br>of required fields<br> <li> Test delete command with both interactive and non-interactive <br>confirmation flows<br> <li> Test cancel-by-scope bulk operation with confirmation, JSON output, <br>and cancelled IDs reporting</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/15/files#diff-89cf85ef9d00f69d946a010101805fe7acf2e135fcf89224a7241cd2ad8c1734">+713/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Add downtimes mock to test fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/conftest.py

<ul><li>Add <code>client.downtimes</code> mock to the <code>mock_client</code> fixture for downtime <br>command testing</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/15/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

