### PR TITLE
feat(slo): add SLO management commands

### DIFF
--- a/ddogctl/cli.py
+++ b/ddogctl/cli.py
@@ -40,6 +40,7 @@ from ddogctl.commands.investigate import investigate
 from ddogctl.commands.service_check import service_check
 from ddogctl.commands.tag import tag
 from ddogctl.commands.downtime import downtime
+from ddogctl.commands.slo import slo
 
 main.add_command(monitor)
 main.add_command(metric)
@@ -52,6 +53,7 @@ main.add_command(investigate)
 main.add_command(service_check)
 main.add_command(tag)
 main.add_command(downtime)
+main.add_command(slo)
 
 
 if __name__ == "__main__":

--- a/ddogctl/client.py
+++ b/ddogctl/client.py
@@ -10,6 +10,7 @@ from datadog_api_client.v1.api import (
     tags_api,
     service_checks_api,
     downtimes_api,
+    service_level_objectives_api,
 )
 from datadog_api_client.v2.api import logs_api, spans_api, service_definition_api
 from ddogctl.config import DatadogConfig
@@ -38,6 +39,7 @@ class DatadogClient:
         self.tags = tags_api.TagsApi(self.api_client)
         self.service_checks = service_checks_api.ServiceChecksApi(self.api_client)
         self.downtimes = downtimes_api.DowntimesApi(self.api_client)
+        self.slos = service_level_objectives_api.ServiceLevelObjectivesApi(self.api_client)
 
         # V2 APIs
         self.logs = logs_api.LogsApi(self.api_client)

--- a/ddogctl/commands/slo.py
+++ b/ddogctl/commands/slo.py
@@ -1,0 +1,412 @@
+"""SLO (Service Level Objective) management commands."""
+
+import click
+import json
+from rich.console import Console
+from rich.table import Table
+from ddogctl.client import get_datadog_client
+from ddogctl.utils.error import handle_api_error
+from ddogctl.utils.file_input import load_json_option
+from ddogctl.utils.confirm import confirm_action
+from ddogctl.utils.export import export_to_json
+from ddogctl.utils.time import parse_time_range
+
+console = Console()
+
+
+def parse_thresholds(threshold_str: str) -> list[dict]:
+    """Parse compact threshold string into list of threshold dicts.
+
+    Format: "timeframe:target[,timeframe:target,...]"
+    Example: "30d:99.9,7d:99.95"
+
+    Returns:
+        List of dicts with 'timeframe' and 'target' keys.
+
+    Raises:
+        ValueError: If the format is invalid.
+    """
+    if not threshold_str or not threshold_str.strip():
+        raise ValueError("Threshold string cannot be empty")
+
+    thresholds = []
+    for part in threshold_str.split(","):
+        part = part.strip()
+        if ":" not in part:
+            raise ValueError(f"Invalid threshold format: '{part}'. Expected 'timeframe:target'")
+        pieces = part.split(":", 1)
+        timeframe = pieces[0].strip()
+        try:
+            target = float(pieces[1].strip())
+        except ValueError:
+            raise ValueError(f"Invalid threshold target in '{part}'. Target must be a number.")
+        thresholds.append({"timeframe": timeframe, "target": target})
+
+    return thresholds
+
+
+@click.group()
+def slo():
+    """SLO (Service Level Objective) management commands."""
+    pass
+
+
+@slo.command(name="list")
+@click.option("--query", help="Search query to filter SLOs")
+@click.option("--tags", "tags_filter", help="Filter by tags (comma-separated)")
+@click.option("--limit", type=int, default=None, help="Maximum number of SLOs to return")
+@click.option(
+    "--format", "fmt", type=click.Choice(["json", "table"]), default="table", help="Output format"
+)
+@handle_api_error
+def list_slos(query, tags_filter, limit, fmt):
+    """List all SLOs."""
+    client = get_datadog_client()
+
+    kwargs = {}
+    if query:
+        kwargs["query"] = query
+    if tags_filter:
+        kwargs["tags_query"] = tags_filter
+    if limit is not None:
+        kwargs["limit"] = limit
+
+    with console.status("[cyan]Fetching SLOs...[/cyan]"):
+        response = client.slos.list_slos(**kwargs)
+
+    slos_list = response.data if response.data else []
+
+    if fmt == "json":
+        output = [s.to_dict() for s in slos_list]
+        print(json.dumps(output, indent=2, default=str))
+    else:
+        table = Table(title="Service Level Objectives")
+        table.add_column("ID", style="cyan", width=14)
+        table.add_column("Name", style="white", min_width=30)
+        table.add_column("Type", style="dim", width=10)
+        table.add_column("Tags", style="dim", width=30)
+
+        for s in slos_list:
+            tag_display = ", ".join(s.tags[:3]) if s.tags else ""
+            if s.tags and len(s.tags) > 3:
+                tag_display += f", +{len(s.tags) - 3} more"
+
+            table.add_row(
+                str(s.id),
+                s.name,
+                str(s.type),
+                tag_display,
+            )
+
+        console.print(table)
+        console.print(f"\n[dim]Total SLOs: {len(slos_list)}[/dim]")
+
+
+@slo.command(name="get")
+@click.argument("slo_id")
+@click.option(
+    "--format", "fmt", type=click.Choice(["json", "table"]), default="table", help="Output format"
+)
+@handle_api_error
+def get_slo(slo_id, fmt):
+    """Get SLO details."""
+    client = get_datadog_client()
+
+    with console.status(f"[cyan]Fetching SLO {slo_id}...[/cyan]"):
+        response = client.slos.get_slo(slo_id)
+
+    slo_data = response.data
+
+    if fmt == "json":
+        print(json.dumps(slo_data.to_dict(), indent=2, default=str))
+    else:
+        console.print(f"\n[bold cyan]SLO {slo_data.id}[/bold cyan]")
+        console.print(f"[bold]Name:[/bold] {slo_data.name}")
+        console.print(f"[bold]Type:[/bold] {slo_data.type}")
+
+        if hasattr(slo_data, "description") and slo_data.description:
+            console.print(f"[bold]Description:[/bold] {slo_data.description}")
+
+        if hasattr(slo_data, "tags") and slo_data.tags:
+            console.print(f"[bold]Tags:[/bold] {', '.join(slo_data.tags)}")
+
+        if hasattr(slo_data, "thresholds") and slo_data.thresholds:
+            console.print("[bold]Thresholds:[/bold]")
+            for t in slo_data.thresholds:
+                if isinstance(t, dict):
+                    console.print(f"  {t.get('timeframe', 'N/A')}: {t.get('target', 'N/A')}%")
+                else:
+                    tf = getattr(t, "timeframe", "N/A")
+                    tgt = getattr(t, "target", "N/A")
+                    console.print(f"  {tf}: {tgt}%")
+
+        if hasattr(slo_data, "creator") and slo_data.creator:
+            email = getattr(slo_data.creator, "email", "N/A")
+            console.print(f"[bold]Creator:[/bold] {email}")
+
+
+@slo.command(name="create")
+@click.option(
+    "--type",
+    "slo_type",
+    type=click.Choice(["metric", "monitor"]),
+    default=None,
+    help="SLO type",
+)
+@click.option("--name", default=None, help="SLO name")
+@click.option("--thresholds", default=None, help="Thresholds (e.g., '30d:99.9,7d:99.95')")
+@click.option("--numerator", default=None, help="Numerator query (metric type)")
+@click.option("--denominator", default=None, help="Denominator query (metric type)")
+@click.option("--monitor-ids", default=None, help="Monitor IDs (comma-separated, monitor type)")
+@click.option("--tags", default=None, help="Tags (comma-separated)")
+@click.option("--description", default=None, help="SLO description")
+@click.option(
+    "-f",
+    "--file",
+    "file_data",
+    callback=load_json_option,
+    default=None,
+    help="JSON file with SLO definition",
+)
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["json", "table"]),
+    default="table",
+    help="Output format",
+)
+@handle_api_error
+def create_slo(
+    slo_type,
+    name,
+    thresholds,
+    numerator,
+    denominator,
+    monitor_ids,
+    tags,
+    description,
+    file_data,
+    fmt,
+):
+    """Create an SLO from inline flags or a JSON file."""
+    if file_data:
+        body = file_data
+    else:
+        # Validate required fields
+        if not slo_type:
+            raise click.UsageError("Missing option '--type' (required without -f)")
+        if not name:
+            raise click.UsageError("Missing option '--name' (required without -f)")
+        if not thresholds:
+            raise click.UsageError("Missing option '--thresholds' (required without -f)")
+
+        parsed_thresholds = parse_thresholds(thresholds)
+
+        body = {
+            "type": slo_type,
+            "name": name,
+            "thresholds": parsed_thresholds,
+        }
+
+        if slo_type == "metric":
+            if not numerator:
+                raise click.UsageError(
+                    "Missing option '--numerator' (required for metric SLO type)"
+                )
+            if not denominator:
+                raise click.UsageError(
+                    "Missing option '--denominator' (required for metric SLO type)"
+                )
+            body["query"] = {
+                "numerator": numerator,
+                "denominator": denominator,
+            }
+        elif slo_type == "monitor":
+            if not monitor_ids:
+                raise click.UsageError(
+                    "Missing option '--monitor-ids' (required for monitor SLO type)"
+                )
+            body["monitor_ids"] = [int(mid.strip()) for mid in monitor_ids.split(",")]
+
+        if tags:
+            body["tags"] = [t.strip() for t in tags.split(",")]
+        if description:
+            body["description"] = description
+
+    client = get_datadog_client()
+
+    with console.status("[cyan]Creating SLO...[/cyan]"):
+        result = client.slos.create_slo(body=body)
+
+    # Result.data is a list of created SLOs
+    created = result.data[0] if result.data else None
+
+    if fmt == "json":
+        if created:
+            print(json.dumps(created.to_dict(), indent=2, default=str))
+        else:
+            print("{}")
+    else:
+        if created:
+            console.print(f"[green]SLO {created.id} created[/green]")
+            console.print(f"[bold]Name:[/bold] {created.name}")
+        else:
+            console.print("[green]SLO created[/green]")
+
+
+@slo.command(name="update")
+@click.argument("slo_id")
+@click.option("--name", default=None, help="SLO name")
+@click.option("--thresholds", default=None, help="Thresholds (e.g., '30d:99.9,7d:99.95')")
+@click.option("--tags", default=None, help="Tags (comma-separated)")
+@click.option("--description", default=None, help="SLO description")
+@click.option(
+    "-f",
+    "--file",
+    "file_data",
+    callback=load_json_option,
+    default=None,
+    help="JSON file with SLO update definition",
+)
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["json", "table"]),
+    default="table",
+    help="Output format",
+)
+@handle_api_error
+def update_slo(slo_id, name, thresholds, tags, description, file_data, fmt):
+    """Update an SLO by ID from inline flags or a JSON file."""
+    if file_data:
+        body = file_data
+    else:
+        body = {}
+        if name is not None:
+            body["name"] = name
+        if thresholds is not None:
+            body["thresholds"] = parse_thresholds(thresholds)
+        if tags is not None:
+            body["tags"] = [t.strip() for t in tags.split(",")]
+        if description is not None:
+            body["description"] = description
+
+        if not body:
+            raise click.UsageError("No update fields specified. Use flags or -f file.json")
+
+    client = get_datadog_client()
+
+    with console.status(f"[cyan]Updating SLO {slo_id}...[/cyan]"):
+        result = client.slos.update_slo(slo_id, body=body)
+
+    updated = result.data[0] if result.data else None
+
+    if fmt == "json":
+        if updated:
+            print(json.dumps(updated.to_dict(), indent=2, default=str))
+        else:
+            print("{}")
+    else:
+        if updated:
+            console.print(f"[green]SLO {slo_id} updated[/green]")
+            console.print(f"[bold]Name:[/bold] {updated.name}")
+        else:
+            console.print(f"[green]SLO {slo_id} updated[/green]")
+
+
+@slo.command(name="delete")
+@click.argument("slo_id")
+@click.option("--confirm", "confirmed", is_flag=True, help="Skip confirmation prompt")
+@handle_api_error
+def delete_slo(slo_id, confirmed):
+    """Delete an SLO by ID."""
+    if not confirm_action(f"Delete SLO {slo_id}?", confirmed):
+        console.print("[yellow]Aborted[/yellow]")
+        return
+
+    client = get_datadog_client()
+
+    with console.status(f"[cyan]Deleting SLO {slo_id}...[/cyan]"):
+        client.slos.delete_slo(slo_id)
+
+    console.print(f"[green]SLO {slo_id} deleted[/green]")
+
+
+@slo.command(name="history")
+@click.argument("slo_id")
+@click.option("--from", "from_time", required=True, help="Start time (e.g., 30d, 7d, 1h)")
+@click.option("--to", "to_time", default="now", help="End time")
+@click.option(
+    "--format", "fmt", type=click.Choice(["json", "table"]), default="table", help="Output format"
+)
+@handle_api_error
+def slo_history(slo_id, from_time, to_time, fmt):
+    """Show SLO history including error budget and burn rate."""
+    client = get_datadog_client()
+
+    from_ts, to_ts = parse_time_range(from_time, to_time)
+
+    with console.status(f"[cyan]Fetching SLO history for {slo_id}...[/cyan]"):
+        response = client.slos.get_slo_history(slo_id, from_ts=from_ts, to_ts=to_ts)
+
+    history_data = response.data
+
+    if fmt == "json":
+        print(json.dumps(history_data.to_dict(), indent=2, default=str))
+    else:
+        console.print(f"\n[bold cyan]SLO History: {slo_id}[/bold cyan]")
+
+        # Overall SLI value
+        if hasattr(history_data, "overall") and history_data.overall:
+            sli = getattr(history_data.overall, "sli_value", None)
+            if sli is not None:
+                console.print(f"[bold]Overall SLI:[/bold] {sli:.4f}%")
+
+        # Threshold details
+        if hasattr(history_data, "thresholds") and history_data.thresholds:
+            table = Table(title="Threshold Status")
+            table.add_column("Timeframe", style="cyan")
+            table.add_column("Target", justify="right", style="yellow")
+            table.add_column("SLI Value", justify="right", style="white")
+            table.add_column("Status", style="bold")
+
+            thresholds = history_data.thresholds
+            if isinstance(thresholds, dict):
+                for tf, details in thresholds.items():
+                    target = getattr(details, "target", None)
+                    sli_val = getattr(details, "sli_value", None)
+
+                    target_str = f"{target}%" if target is not None else "N/A"
+                    sli_str = f"{sli_val:.4f}%" if sli_val is not None else "N/A"
+
+                    if target is not None and sli_val is not None:
+                        status = "[green]OK[/green]" if sli_val >= target else "[red]BREACHED[/red]"
+                    else:
+                        status = "[dim]N/A[/dim]"
+
+                    table.add_row(tf, target_str, sli_str, status)
+
+            console.print(table)
+
+
+@slo.command(name="export")
+@click.argument("slo_id")
+@click.option(
+    "-o",
+    "--output",
+    "output_file",
+    required=True,
+    help="Output file path",
+)
+@handle_api_error
+def export_slo(slo_id, output_file):
+    """Export an SLO definition to a JSON file for GitOps workflows."""
+    client = get_datadog_client()
+
+    with console.status(f"[cyan]Fetching SLO {slo_id}...[/cyan]"):
+        response = client.slos.get_slo(slo_id)
+
+    slo_data = response.data
+    export_to_json(slo_data.to_dict(), output_file)
+
+    console.print(f"[green]Exported SLO {slo_id} to {output_file}[/green]")

--- a/tests/commands/test_slo.py
+++ b/tests/commands/test_slo.py
@@ -1,0 +1,640 @@
+"""Tests for SLO management commands."""
+
+import json
+import pytest
+from unittest.mock import Mock, patch
+from click.testing import CliRunner
+from ddogctl.commands.slo import slo, parse_thresholds
+
+# ============================================================================
+# parse_thresholds Tests
+# ============================================================================
+
+
+class TestParseThresholds:
+    """Tests for the parse_thresholds helper function."""
+
+    def test_single_threshold(self):
+        """Test parsing a single threshold."""
+        result = parse_thresholds("30d:99.9")
+        assert result == [{"timeframe": "30d", "target": 99.9}]
+
+    def test_multiple_thresholds(self):
+        """Test parsing multiple comma-separated thresholds."""
+        result = parse_thresholds("30d:99.9,7d:99.95")
+        assert result == [
+            {"timeframe": "30d", "target": 99.9},
+            {"timeframe": "7d", "target": 99.95},
+        ]
+
+    def test_three_thresholds(self):
+        """Test parsing three thresholds."""
+        result = parse_thresholds("30d:99.9,7d:99.95,90d:99.5")
+        assert len(result) == 3
+        assert result[0]["timeframe"] == "30d"
+        assert result[1]["timeframe"] == "7d"
+        assert result[2]["timeframe"] == "90d"
+
+    def test_integer_target(self):
+        """Test parsing a threshold with an integer target."""
+        result = parse_thresholds("30d:99")
+        assert result == [{"timeframe": "30d", "target": 99.0}]
+
+    def test_invalid_format_missing_colon(self):
+        """Test that missing colon raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid threshold"):
+            parse_thresholds("30d99.9")
+
+    def test_invalid_target_not_a_number(self):
+        """Test that non-numeric target raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid threshold"):
+            parse_thresholds("30d:abc")
+
+    def test_empty_string(self):
+        """Test that empty string raises ValueError."""
+        with pytest.raises(ValueError):
+            parse_thresholds("")
+
+
+# ============================================================================
+# SLO List Command Tests
+# ============================================================================
+
+
+@pytest.fixture
+def mock_client():
+    """Create a mock Datadog client."""
+    client = Mock()
+    client.slos = Mock()
+    return client
+
+
+@pytest.fixture
+def runner():
+    """Click CLI test runner."""
+    return CliRunner()
+
+
+def _make_mock_slo(slo_id, name, slo_type, tags=None, thresholds=None, description=""):
+    """Factory for mock SLO objects."""
+
+    class MockSLO:
+        def __init__(self):
+            self.id = slo_id
+            self.name = name
+            self.type = slo_type
+            self.tags = tags or []
+            self.thresholds = thresholds or []
+            self.description = description
+            self.creator = Mock(email="test@example.com")
+            self.created_at = 1700000000
+            self.modified_at = 1700100000
+
+        def to_dict(self):
+            return {
+                "id": self.id,
+                "name": self.name,
+                "type": self.type,
+                "tags": self.tags,
+                "thresholds": [t if isinstance(t, dict) else t for t in self.thresholds],
+                "description": self.description,
+            }
+
+    return MockSLO()
+
+
+def test_slo_list_table_format(mock_client, runner):
+    """Test listing SLOs with table format."""
+    mock_slos = [
+        _make_mock_slo("abc123", "API Availability", "metric", tags=["team:platform"]),
+        _make_mock_slo("def456", "DB Health", "monitor", tags=["team:infra"]),
+    ]
+    mock_client.slos.list_slos.return_value = Mock(data=mock_slos)
+
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(slo, ["list"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "API Availability" in result.output
+        assert "DB Health" in result.output
+        assert "Total SLOs: 2" in result.output
+
+
+def test_slo_list_json_format(mock_client, runner):
+    """Test listing SLOs with JSON format."""
+    mock_slos = [
+        _make_mock_slo("abc123", "API Availability", "metric", tags=["team:platform"]),
+    ]
+    mock_client.slos.list_slos.return_value = Mock(data=mock_slos)
+
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(slo, ["list", "--format", "json"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert len(output) == 1
+        assert output[0]["id"] == "abc123"
+        assert output[0]["name"] == "API Availability"
+
+
+def test_slo_list_with_query(mock_client, runner):
+    """Test listing SLOs with a search query."""
+    mock_slos = [
+        _make_mock_slo("abc123", "API Availability", "metric"),
+    ]
+    mock_client.slos.list_slos.return_value = Mock(data=mock_slos)
+
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(slo, ["list", "--query", "API"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        mock_client.slos.list_slos.assert_called_once()
+        call_kwargs = mock_client.slos.list_slos.call_args
+        # query should be passed as a keyword arg
+        assert "query" in call_kwargs[1] or (call_kwargs[0] and "API" in str(call_kwargs))
+
+
+def test_slo_list_with_tags_filter(mock_client, runner):
+    """Test listing SLOs with tags filter."""
+    mock_slos = [
+        _make_mock_slo("abc123", "API Availability", "metric", tags=["team:platform"]),
+    ]
+    mock_client.slos.list_slos.return_value = Mock(data=mock_slos)
+
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(slo, ["list", "--tags", "team:platform"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        mock_client.slos.list_slos.assert_called_once()
+        call_kwargs = mock_client.slos.list_slos.call_args
+        assert "tags_query" in call_kwargs[1]
+
+
+def test_slo_list_with_limit(mock_client, runner):
+    """Test listing SLOs with limit."""
+    mock_slos = [
+        _make_mock_slo("abc123", "API Availability", "metric"),
+    ]
+    mock_client.slos.list_slos.return_value = Mock(data=mock_slos)
+
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(slo, ["list", "--limit", "5"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        call_kwargs = mock_client.slos.list_slos.call_args
+        assert "limit" in call_kwargs[1]
+        assert call_kwargs[1]["limit"] == 5
+
+
+def test_slo_list_empty(mock_client, runner):
+    """Test listing SLOs when none exist."""
+    mock_client.slos.list_slos.return_value = Mock(data=[])
+
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(slo, ["list"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Total SLOs: 0" in result.output
+
+
+# ============================================================================
+# SLO Get Command Tests
+# ============================================================================
+
+
+def test_slo_get_table_format(mock_client, runner):
+    """Test getting a single SLO with table format."""
+    mock_slo = _make_mock_slo(
+        "abc123",
+        "API Availability",
+        "metric",
+        tags=["team:platform"],
+        description="API availability SLO",
+    )
+    mock_client.slos.get_slo.return_value = Mock(data=mock_slo)
+
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(slo, ["get", "abc123"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "abc123" in result.output
+        assert "API Availability" in result.output
+        assert "metric" in result.output
+
+
+def test_slo_get_json_format(mock_client, runner):
+    """Test getting a single SLO with JSON format."""
+    mock_slo = _make_mock_slo("abc123", "API Availability", "metric")
+    mock_client.slos.get_slo.return_value = Mock(data=mock_slo)
+
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(slo, ["get", "abc123", "--format", "json"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["id"] == "abc123"
+        assert output["name"] == "API Availability"
+
+
+# ============================================================================
+# SLO Create Command Tests
+# ============================================================================
+
+
+def test_slo_create_metric_type(mock_client, runner):
+    """Test creating a metric-based SLO with inline flags."""
+    created_slo = _make_mock_slo("new123", "API Availability", "metric")
+    mock_client.slos.create_slo.return_value = Mock(data=[created_slo])
+
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            slo,
+            [
+                "create",
+                "--type",
+                "metric",
+                "--name",
+                "API Availability",
+                "--thresholds",
+                "30d:99.9,7d:99.95",
+                "--numerator",
+                "sum:api.requests.success{*}",
+                "--denominator",
+                "sum:api.requests.total{*}",
+                "--tags",
+                "team:platform",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "SLO" in result.output and "created" in result.output
+        mock_client.slos.create_slo.assert_called_once()
+
+
+def test_slo_create_monitor_type(mock_client, runner):
+    """Test creating a monitor-based SLO with inline flags."""
+    created_slo = _make_mock_slo("new456", "DB Health", "monitor")
+    mock_client.slos.create_slo.return_value = Mock(data=[created_slo])
+
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            slo,
+            [
+                "create",
+                "--type",
+                "monitor",
+                "--name",
+                "DB Health",
+                "--monitor-ids",
+                "123,456",
+                "--thresholds",
+                "30d:99.9",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "SLO" in result.output and "created" in result.output
+        mock_client.slos.create_slo.assert_called_once()
+
+
+def test_slo_create_from_file(mock_client, runner, tmp_path):
+    """Test creating an SLO from a JSON file."""
+    slo_def = {
+        "type": "metric",
+        "name": "API SLO from file",
+        "thresholds": [{"timeframe": "30d", "target": 99.9}],
+        "query": {
+            "numerator": "sum:api.requests.success{*}",
+            "denominator": "sum:api.requests.total{*}",
+        },
+        "tags": ["team:platform"],
+    }
+    json_file = tmp_path / "slo.json"
+    json_file.write_text(json.dumps(slo_def))
+
+    created_slo = _make_mock_slo("file123", "API SLO from file", "metric")
+    mock_client.slos.create_slo.return_value = Mock(data=[created_slo])
+
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(slo, ["create", "-f", str(json_file)])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "SLO" in result.output and "created" in result.output
+        mock_client.slos.create_slo.assert_called_once()
+
+
+def test_slo_create_missing_required_metric_fields(mock_client, runner):
+    """Test that metric SLO requires numerator and denominator."""
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            slo,
+            [
+                "create",
+                "--type",
+                "metric",
+                "--name",
+                "Test",
+                "--thresholds",
+                "30d:99.9",
+                # Missing --numerator and --denominator
+            ],
+        )
+
+        assert result.exit_code != 0
+
+
+def test_slo_create_missing_required_monitor_fields(mock_client, runner):
+    """Test that monitor SLO requires monitor-ids."""
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            slo,
+            [
+                "create",
+                "--type",
+                "monitor",
+                "--name",
+                "Test",
+                "--thresholds",
+                "30d:99.9",
+                # Missing --monitor-ids
+            ],
+        )
+
+        assert result.exit_code != 0
+
+
+def test_slo_create_missing_name(mock_client, runner):
+    """Test that create fails when --name is missing without -f."""
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            slo,
+            [
+                "create",
+                "--type",
+                "metric",
+                "--thresholds",
+                "30d:99.9",
+                "--numerator",
+                "sum:ok{*}",
+                "--denominator",
+                "sum:total{*}",
+            ],
+        )
+
+        assert result.exit_code != 0
+
+
+def test_slo_create_missing_thresholds(mock_client, runner):
+    """Test that create fails when --thresholds is missing without -f."""
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            slo,
+            [
+                "create",
+                "--type",
+                "metric",
+                "--name",
+                "Test",
+                "--numerator",
+                "sum:ok{*}",
+                "--denominator",
+                "sum:total{*}",
+            ],
+        )
+
+        assert result.exit_code != 0
+
+
+def test_slo_create_json_output(mock_client, runner):
+    """Test creating an SLO with JSON output format."""
+    created_slo = _make_mock_slo("json123", "JSON Test SLO", "metric")
+    mock_client.slos.create_slo.return_value = Mock(data=[created_slo])
+
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            slo,
+            [
+                "create",
+                "--type",
+                "metric",
+                "--name",
+                "JSON Test SLO",
+                "--thresholds",
+                "30d:99.9",
+                "--numerator",
+                "sum:ok{*}",
+                "--denominator",
+                "sum:total{*}",
+                "--format",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["id"] == "json123"
+
+
+# ============================================================================
+# SLO Update Command Tests
+# ============================================================================
+
+
+def test_slo_update_with_inline_flags(mock_client, runner):
+    """Test updating an SLO with inline flags."""
+    updated_slo = _make_mock_slo("abc123", "Updated SLO", "metric")
+    mock_client.slos.update_slo.return_value = Mock(data=[updated_slo])
+
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            slo,
+            [
+                "update",
+                "abc123",
+                "--name",
+                "Updated SLO",
+                "--thresholds",
+                "30d:99.95",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "updated" in result.output
+        mock_client.slos.update_slo.assert_called_once()
+
+
+def test_slo_update_from_file(mock_client, runner, tmp_path):
+    """Test updating an SLO from a JSON file."""
+    slo_def = {
+        "name": "Updated from file",
+        "thresholds": [{"timeframe": "30d", "target": 99.95}],
+    }
+    json_file = tmp_path / "slo_update.json"
+    json_file.write_text(json.dumps(slo_def))
+
+    updated_slo = _make_mock_slo("abc123", "Updated from file", "metric")
+    mock_client.slos.update_slo.return_value = Mock(data=[updated_slo])
+
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(slo, ["update", "abc123", "-f", str(json_file)])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "updated" in result.output
+        mock_client.slos.update_slo.assert_called_once()
+
+
+def test_slo_update_no_fields(mock_client, runner):
+    """Test that update fails when no fields are specified."""
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(slo, ["update", "abc123"])
+
+        assert result.exit_code != 0
+
+
+def test_slo_update_json_output(mock_client, runner):
+    """Test updating an SLO with JSON output format."""
+    updated_slo = _make_mock_slo("abc123", "JSON Update", "metric")
+    mock_client.slos.update_slo.return_value = Mock(data=[updated_slo])
+
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            slo,
+            ["update", "abc123", "--name", "JSON Update", "--format", "json"],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["id"] == "abc123"
+
+
+# ============================================================================
+# SLO Delete Command Tests
+# ============================================================================
+
+
+def test_slo_delete_with_confirm_flag(mock_client, runner):
+    """Test deleting an SLO with --confirm flag (no prompt)."""
+    mock_client.slos.delete_slo.return_value = Mock()
+
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(slo, ["delete", "abc123", "--confirm"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "deleted" in result.output
+        mock_client.slos.delete_slo.assert_called_once_with("abc123")
+
+
+def test_slo_delete_interactive_confirm_yes(mock_client, runner):
+    """Test deleting an SLO with interactive confirmation (user says yes)."""
+    mock_client.slos.delete_slo.return_value = Mock()
+
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(slo, ["delete", "abc123"], input="y\n")
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "deleted" in result.output
+        mock_client.slos.delete_slo.assert_called_once_with("abc123")
+
+
+def test_slo_delete_interactive_confirm_no(mock_client, runner):
+    """Test deleting an SLO with interactive confirmation (user says no)."""
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(slo, ["delete", "abc123"], input="n\n")
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Aborted" in result.output
+        mock_client.slos.delete_slo.assert_not_called()
+
+
+# ============================================================================
+# SLO History Command Tests
+# ============================================================================
+
+
+def test_slo_history_table_format(mock_client, runner):
+    """Test SLO history with table format."""
+    mock_history = Mock()
+    mock_history.data = Mock()
+    mock_history.data.overall = Mock()
+    mock_history.data.overall.sli_value = 99.95
+    mock_history.data.overall.span_precision = 2
+    mock_history.data.thresholds = {
+        "30d": Mock(
+            target=99.9,
+            timeframe="30d",
+            target_display="99.9",
+            sli_value=99.95,
+        ),
+    }
+    mock_history.data.to_dict = lambda: {
+        "overall": {"sli_value": 99.95},
+        "thresholds": {
+            "30d": {"target": 99.9, "timeframe": "30d", "sli_value": 99.95},
+        },
+    }
+
+    mock_client.slos.get_slo_history.return_value = mock_history
+
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(slo, ["history", "abc123", "--from", "30d"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        mock_client.slos.get_slo_history.assert_called_once()
+
+
+def test_slo_history_json_format(mock_client, runner):
+    """Test SLO history with JSON format."""
+    mock_history = Mock()
+    mock_history.data = Mock()
+    mock_history.data.to_dict.return_value = {
+        "overall": {"sli_value": 99.95},
+        "thresholds": {
+            "30d": {"target": 99.9, "timeframe": "30d", "sli_value": 99.95},
+        },
+    }
+
+    mock_client.slos.get_slo_history.return_value = mock_history
+
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(slo, ["history", "abc123", "--from", "30d", "--format", "json"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert "overall" in output
+
+
+# ============================================================================
+# SLO Export Command Tests
+# ============================================================================
+
+
+def test_slo_export(mock_client, runner, tmp_path):
+    """Test exporting an SLO to JSON file."""
+    mock_slo = _make_mock_slo(
+        "abc123",
+        "API Availability",
+        "metric",
+        tags=["team:platform"],
+    )
+    mock_client.slos.get_slo.return_value = Mock(data=mock_slo)
+
+    output_file = tmp_path / "slo_export.json"
+
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(slo, ["export", "abc123", "-o", str(output_file)])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Exported" in result.output
+
+        # Verify the exported file
+        exported = json.loads(output_file.read_text())
+        assert exported["id"] == "abc123"
+        assert exported["name"] == "API Availability"
+
+
+def test_slo_export_missing_output(mock_client, runner):
+    """Test that export fails when -o is not specified."""
+    with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(slo, ["export", "abc123"])
+
+        assert result.exit_code != 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ def mock_client():
     client.service_definitions = Mock()
     client.service_checks = Mock()
     client.downtimes = Mock()
+    client.slos = Mock()
     return client
 
 


### PR DESCRIPTION
### **User description**
## Summary
- Add `slo` command group with list, get, create, update, delete, history, and export subcommands
- Support both metric and monitor SLO types
- Add `parse_thresholds()` helper for compact threshold format (`30d:99.9,7d:99.95`)
- Add `ServiceLevelObjectivesApi` to `DatadogClient`
- Full TDD test coverage (34 tests) following existing patterns

## Test plan
- [x] All tests pass (`uv run pytest tests/ -v` -- 352 passed)
- [x] Black formatting passes
- [x] Ruff linting passes


___

### **PR Type**
Enhancement


___

### **Description**
- Add comprehensive SLO management command group with 7 subcommands
  - list, get, create, update, delete, history, export operations

- Implement `parse_thresholds()` helper for compact threshold format parsing

- Integrate `ServiceLevelObjectivesApi` into `DatadogClient` for API access

- Support both metric and monitor SLO types with flexible configuration

- Include 34 comprehensive tests with full TDD coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["CLI Entry Point<br/>ddogctl/cli.py"]
  SLO["SLO Command Group<br/>ddogctl/commands/slo.py"]
  CLIENT["DatadogClient<br/>ddogctl/client.py"]
  API["ServiceLevelObjectivesApi<br/>Datadog v1 API"]
  TESTS["Test Suite<br/>tests/commands/test_slo.py"]
  
  CLI -- "imports & registers" --> SLO
  SLO -- "uses get_datadog_client()" --> CLIENT
  CLIENT -- "wraps" --> API
  SLO -- "tested by" --> TESTS
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.py</strong><dd><code>Register SLO command group with CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/cli.py

<ul><li>Import <code>slo</code> command group from <code>ddogctl.commands.slo</code><br> <li> Register <code>slo</code> command with main CLI group</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/16/files#diff-1ca1a58dd47b18afff9b729ec6430c335581acb24899da2e49951588191ea17e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Add SLO API client integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/client.py

<ul><li>Import <code>service_level_objectives_api</code> from datadog_api_client.v1.api<br> <li> Initialize <code>ServiceLevelObjectivesApi</code> instance as <code>self.slos</code> attribute</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/16/files#diff-4e22d74821607a2dc683b1c483fe0aa643ff5dc3aab9f76c1e5b4373c0f6bf57">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>slo.py</strong><dd><code>Implement complete SLO management command suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/commands/slo.py

<ul><li>Implement <code>parse_thresholds()</code> helper function for parsing compact <br>threshold format (e.g., "30d:99.9,7d:99.95")<br> <li> Create <code>slo</code> command group with 7 subcommands: list, get, create, <br>update, delete, history, export<br> <li> Support both metric and monitor SLO types with type-specific <br>validation<br> <li> Implement list command with query, tags filter, limit, and format <br>options<br> <li> Implement get command with detailed SLO information display<br> <li> Implement create command supporting inline flags and JSON file input<br> <li> Implement update command for modifying existing SLOs<br> <li> Implement delete command with confirmation prompt<br> <li> Implement history command showing SLI values and threshold status<br> <li> Implement export command for GitOps workflows</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/16/files#diff-783a86c141900a063bbe754862eaa5ffb74a7cdff09125c032013f97e54fe89a">+412/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_slo.py</strong><dd><code>Add comprehensive SLO command test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/commands/test_slo.py

<ul><li>Add 34 comprehensive tests covering all SLO commands and helper <br>functions<br> <li> Test <code>parse_thresholds()</code> with valid/invalid formats and edge cases<br> <li> Test list command with various filters, formats, and empty results<br> <li> Test get command with table and JSON output formats<br> <li> Test create command for metric and monitor types with inline flags and <br>file input<br> <li> Test create command validation for required fields<br> <li> Test update command with inline flags, file input, and validation<br> <li> Test delete command with interactive and non-interactive confirmation<br> <li> Test history command with table and JSON formats<br> <li> Test export command with file output verification</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/16/files#diff-ca9ad937ff1596dc4f309b67f2cec01dbb10ab49c4e1df4127a3955f256707f4">+640/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Update mock client fixture for SLO tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/conftest.py

<ul><li>Add <code>client.slos</code> mock to the <code>mock_client</code> fixture for test compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/16/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

