### PR TITLE
feat(dashboard): add dashboard management commands

### DIFF
--- a/ddogctl/cli.py
+++ b/ddogctl/cli.py
@@ -41,6 +41,7 @@ from ddogctl.commands.service_check import service_check
 from ddogctl.commands.tag import tag
 from ddogctl.commands.downtime import downtime
 from ddogctl.commands.slo import slo
+from ddogctl.commands.dashboard import dashboard
 
 main.add_command(monitor)
 main.add_command(metric)
@@ -54,6 +55,7 @@ main.add_command(service_check)
 main.add_command(tag)
 main.add_command(downtime)
 main.add_command(slo)
+main.add_command(dashboard)
 
 
 if __name__ == "__main__":

--- a/ddogctl/client.py
+++ b/ddogctl/client.py
@@ -11,6 +11,7 @@ from datadog_api_client.v1.api import (
     service_checks_api,
     downtimes_api,
     service_level_objectives_api,
+    dashboards_api,
 )
 from datadog_api_client.v2.api import logs_api, spans_api, service_definition_api
 from ddogctl.config import DatadogConfig
@@ -40,6 +41,7 @@ class DatadogClient:
         self.service_checks = service_checks_api.ServiceChecksApi(self.api_client)
         self.downtimes = downtimes_api.DowntimesApi(self.api_client)
         self.slos = service_level_objectives_api.ServiceLevelObjectivesApi(self.api_client)
+        self.dashboards = dashboards_api.DashboardsApi(self.api_client)
 
         # V2 APIs
         self.logs = logs_api.LogsApi(self.api_client)

--- a/ddogctl/commands/dashboard.py
+++ b/ddogctl/commands/dashboard.py
@@ -1,0 +1,291 @@
+"""Dashboard management commands."""
+
+import click
+import json
+from rich.console import Console
+from rich.table import Table
+from ddogctl.client import get_datadog_client
+from ddogctl.utils.error import handle_api_error
+from ddogctl.utils.file_input import load_json_option
+from ddogctl.utils.confirm import confirm_action
+from ddogctl.utils.export import export_to_json
+
+console = Console()
+
+
+@click.group()
+def dashboard():
+    """Dashboard management commands."""
+    pass
+
+
+@dashboard.command(name="list")
+@click.option("--tags", help="Filter by tags (comma-separated)")
+@click.option(
+    "--format", type=click.Choice(["json", "table"]), default="table", help="Output format"
+)
+@handle_api_error
+def list_dashboards(tags, format):
+    """List all dashboards."""
+    client = get_datadog_client()
+
+    kwargs = {}
+    if tags:
+        kwargs["filter_configured"] = tags
+
+    with console.status("[cyan]Fetching dashboards...[/cyan]"):
+        response = client.dashboards.list_dashboards(**kwargs)
+
+    dashboards_list = response.dashboards or []
+
+    if format == "json":
+        output = []
+        for d in dashboards_list:
+            output.append(
+                {
+                    "id": d.id,
+                    "title": d.title,
+                    "layout_type": str(d.layout_type),
+                    "author_handle": getattr(d, "author_handle", ""),
+                    "created_at": str(getattr(d, "created_at", "")),
+                    "url": getattr(d, "url", ""),
+                }
+            )
+        print(json.dumps(output, indent=2, default=str))
+    else:
+        table = Table(title="Dashboards", show_lines=False)
+        table.add_column("ID", style="cyan", no_wrap=True)
+        table.add_column("Title", style="white", min_width=30)
+        table.add_column("Layout", style="dim", width=10)
+        table.add_column("Author", style="dim")
+
+        for d in dashboards_list:
+            table.add_row(
+                str(d.id),
+                str(d.title),
+                str(getattr(d, "layout_type", "")),
+                str(getattr(d, "author_handle", "")),
+            )
+
+        console.print(table)
+        console.print(f"\n[dim]Total dashboards: {len(dashboards_list)}[/dim]")
+
+
+@dashboard.command(name="get")
+@click.argument("dashboard_id")
+@click.option(
+    "--format", type=click.Choice(["json", "table"]), default="table", help="Output format"
+)
+@handle_api_error
+def get_dashboard(dashboard_id, format):
+    """Get dashboard details."""
+    client = get_datadog_client()
+
+    with console.status(f"[cyan]Fetching dashboard {dashboard_id}...[/cyan]"):
+        dash = client.dashboards.get_dashboard(dashboard_id)
+
+    if format == "json":
+        print(json.dumps(dash.to_dict(), indent=2, default=str))
+    else:
+        console.print(f"\n[bold cyan]Dashboard {dash.id}[/bold cyan]")
+        console.print(f"[bold]Title:[/bold] {dash.title}")
+        console.print(f"[bold]Layout:[/bold] {dash.layout_type}")
+
+        if hasattr(dash, "description") and dash.description:
+            console.print(f"[bold]Description:[/bold] {dash.description}")
+
+        if hasattr(dash, "author_handle") and dash.author_handle:
+            console.print(f"[bold]Author:[/bold] {dash.author_handle}")
+
+        if hasattr(dash, "created_at") and dash.created_at:
+            console.print(f"[bold]Created:[/bold] {dash.created_at}")
+
+        if hasattr(dash, "url") and dash.url:
+            console.print(f"[bold]URL:[/bold] {dash.url}")
+
+        widget_count = len(dash.widgets) if hasattr(dash, "widgets") and dash.widgets else 0
+        console.print(f"[bold]Widgets:[/bold] {widget_count}")
+
+
+@dashboard.command(name="create")
+@click.option("--title", default=None, help="Dashboard title")
+@click.option(
+    "--layout-type",
+    type=click.Choice(["ordered", "free"]),
+    default=None,
+    help="Layout type (ordered=grid, free=freeform)",
+)
+@click.option("--description", default=None, help="Dashboard description")
+@click.option(
+    "-f",
+    "--file",
+    "file_data",
+    callback=load_json_option,
+    default=None,
+    help="JSON file with dashboard definition",
+)
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["json", "table"]),
+    default="table",
+    help="Output format",
+)
+@handle_api_error
+def create_dashboard_cmd(title, layout_type, description, file_data, fmt):
+    """Create a dashboard from a JSON file or inline flags.
+
+    From file (primary workflow):
+        ddogctl dashboard create -f dashboard.json
+
+    With inline flags (metadata only, no widgets):
+        ddogctl dashboard create --title "My Dashboard" --layout-type ordered
+    """
+    if file_data:
+        body = file_data
+    else:
+        if not title:
+            raise click.UsageError("Missing option '--title' (required without -f)")
+        if not layout_type:
+            raise click.UsageError("Missing option '--layout-type' (required without -f)")
+
+        body = {
+            "title": title,
+            "layout_type": layout_type,
+            "widgets": [],
+        }
+        if description:
+            body["description"] = description
+
+    client = get_datadog_client()
+
+    with console.status("[cyan]Creating dashboard...[/cyan]"):
+        result = client.dashboards.create_dashboard(body=body)
+
+    if fmt == "json":
+        print(json.dumps(result.to_dict(), indent=2, default=str))
+    else:
+        console.print(f"[green]Dashboard {result.id} created[/green]")
+        console.print(f"[bold]Title:[/bold] {result.title}")
+
+
+@dashboard.command(name="update")
+@click.argument("dashboard_id")
+@click.option(
+    "-f",
+    "--file",
+    "file_data",
+    callback=load_json_option,
+    default=None,
+    help="JSON file with dashboard definition",
+)
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["json", "table"]),
+    default="table",
+    help="Output format",
+)
+@handle_api_error
+def update_dashboard_cmd(dashboard_id, file_data, fmt):
+    """Update a dashboard by ID from a JSON file.
+
+    Usage:
+        ddogctl dashboard update <dashboard_id> -f dashboard.json
+    """
+    if not file_data:
+        raise click.UsageError("Missing option '-f' / '--file' (required for update)")
+
+    client = get_datadog_client()
+
+    with console.status(f"[cyan]Updating dashboard {dashboard_id}...[/cyan]"):
+        result = client.dashboards.update_dashboard(dashboard_id, body=file_data)
+
+    if fmt == "json":
+        print(json.dumps(result.to_dict(), indent=2, default=str))
+    else:
+        console.print(f"[green]Dashboard {dashboard_id} updated[/green]")
+        console.print(f"[bold]Title:[/bold] {result.title}")
+
+
+@dashboard.command(name="delete")
+@click.argument("dashboard_id")
+@click.option("--confirm", "confirmed", is_flag=True, help="Skip confirmation prompt")
+@handle_api_error
+def delete_dashboard_cmd(dashboard_id, confirmed):
+    """Delete a dashboard by ID."""
+    if not confirm_action(f"Delete dashboard {dashboard_id}?", confirmed):
+        console.print("[yellow]Aborted[/yellow]")
+        return
+
+    client = get_datadog_client()
+
+    with console.status(f"[cyan]Deleting dashboard {dashboard_id}...[/cyan]"):
+        client.dashboards.delete_dashboard(dashboard_id)
+
+    console.print(f"[green]Dashboard {dashboard_id} deleted[/green]")
+
+
+@dashboard.command(name="export")
+@click.argument("dashboard_id")
+@click.option(
+    "-o",
+    "--output",
+    "output_file",
+    required=True,
+    help="Output JSON file path",
+)
+@handle_api_error
+def export_dashboard_cmd(dashboard_id, output_file):
+    """Export a dashboard to a JSON file.
+
+    Useful for the export -> modify -> apply GitOps workflow.
+    """
+    client = get_datadog_client()
+
+    with console.status(f"[cyan]Fetching dashboard {dashboard_id}...[/cyan]"):
+        dash = client.dashboards.get_dashboard(dashboard_id)
+
+    data = dash.to_dict()
+    export_to_json(data, output_file)
+    console.print(f"[green]Dashboard {dashboard_id} exported to {output_file}[/green]")
+
+
+@dashboard.command(name="clone")
+@click.argument("dashboard_id")
+@click.option("--title", required=True, help="Title for the cloned dashboard")
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["json", "table"]),
+    default="table",
+    help="Output format",
+)
+@handle_api_error
+def clone_dashboard_cmd(dashboard_id, title, fmt):
+    """Clone a dashboard with a new title.
+
+    Fetches the source dashboard definition, then creates a new dashboard
+    with the same widgets and the specified title.
+    """
+    client = get_datadog_client()
+
+    with console.status(f"[cyan]Fetching dashboard {dashboard_id}...[/cyan]"):
+        original = client.dashboards.get_dashboard(dashboard_id)
+
+    # Build the clone body from the original
+    clone_body = original.to_dict()
+    clone_body["title"] = title
+
+    # Remove fields that shouldn't be copied to the clone
+    for field in ["id", "author_handle", "created_at", "modified_at", "url"]:
+        clone_body.pop(field, None)
+
+    with console.status("[cyan]Creating cloned dashboard...[/cyan]"):
+        result = client.dashboards.create_dashboard(body=clone_body)
+
+    if fmt == "json":
+        print(json.dumps(result.to_dict(), indent=2, default=str))
+    else:
+        console.print(f"[green]Dashboard {dashboard_id} cloned as {result.id}[/green]")
+        console.print(f"[bold]Title:[/bold] {result.title}")

--- a/tests/commands/test_dashboard.py
+++ b/tests/commands/test_dashboard.py
@@ -1,0 +1,613 @@
+"""Tests for dashboard management commands."""
+
+import json
+import pytest
+from unittest.mock import Mock, patch
+from click.testing import CliRunner
+from ddogctl.commands.dashboard import dashboard
+
+
+@pytest.fixture
+def mock_client():
+    """Create a mock Datadog client."""
+    client = Mock()
+    client.dashboards = Mock()
+    return client
+
+
+@pytest.fixture
+def runner():
+    """Click CLI test runner."""
+    return CliRunner()
+
+
+class MockDashboardSummary:
+    """Mock dashboard summary object (from list_dashboards)."""
+
+    def __init__(
+        self,
+        id,
+        title,
+        layout_type="ordered",
+        author_handle="user@example.com",
+        created_at="2024-01-15T10:00:00Z",
+        url="/dashboard/abc-123",
+    ):
+        self.id = id
+        self.title = title
+        self.layout_type = layout_type
+        self.author_handle = author_handle
+        self.created_at = created_at
+        self.url = url
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "title": self.title,
+            "layout_type": self.layout_type,
+            "author_handle": self.author_handle,
+            "created_at": self.created_at,
+            "url": self.url,
+        }
+
+
+class MockDashboardListResponse:
+    """Mock list_dashboards response."""
+
+    def __init__(self, dashboards):
+        self.dashboards = dashboards
+
+    def to_dict(self):
+        return {"dashboards": [d.to_dict() for d in self.dashboards]}
+
+
+class MockDashboard:
+    """Mock full dashboard object (from get/create/update)."""
+
+    def __init__(
+        self,
+        id,
+        title,
+        layout_type="ordered",
+        description="",
+        author_handle="user@example.com",
+        created_at="2024-01-15T10:00:00Z",
+        url="/dashboard/abc-123",
+        widgets=None,
+    ):
+        self.id = id
+        self.title = title
+        self.layout_type = layout_type
+        self.description = description
+        self.author_handle = author_handle
+        self.created_at = created_at
+        self.url = url
+        self.widgets = widgets or []
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "title": self.title,
+            "layout_type": self.layout_type,
+            "description": self.description,
+            "author_handle": self.author_handle,
+            "created_at": self.created_at,
+            "url": self.url,
+            "widgets": self.widgets,
+        }
+
+
+# ============================================================================
+# Dashboard List Command Tests
+# ============================================================================
+
+
+def test_dashboard_list_table_format(mock_client, runner):
+    """Test listing dashboards in table format (default)."""
+    mock_dashboards = [
+        MockDashboardSummary(
+            "abc-123", "Production Overview", "ordered", "admin@example.com", "2024-01-15T10:00:00Z"
+        ),
+        MockDashboardSummary(
+            "def-456", "Staging Metrics", "free", "dev@example.com", "2024-02-01T12:00:00Z"
+        ),
+    ]
+    response = MockDashboardListResponse(mock_dashboards)
+    mock_client.dashboards.list_dashboards.return_value = response
+
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(dashboard, ["list"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Dashboards" in result.output
+        assert "Production Overview" in result.output
+        assert "Staging Metrics" in result.output
+        assert "Total dashboards: 2" in result.output
+
+
+def test_dashboard_list_json_format(mock_client, runner):
+    """Test listing dashboards in JSON format."""
+    mock_dashboards = [
+        MockDashboardSummary("abc-123", "Production Overview"),
+        MockDashboardSummary("def-456", "Staging Metrics", "free"),
+    ]
+    response = MockDashboardListResponse(mock_dashboards)
+    mock_client.dashboards.list_dashboards.return_value = response
+
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(dashboard, ["list", "--format", "json"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert len(output) == 2
+        assert output[0]["id"] == "abc-123"
+        assert output[0]["title"] == "Production Overview"
+        assert output[1]["id"] == "def-456"
+        assert output[1]["layout_type"] == "free"
+
+
+def test_dashboard_list_empty(mock_client, runner):
+    """Test listing dashboards when none exist."""
+    response = MockDashboardListResponse([])
+    mock_client.dashboards.list_dashboards.return_value = response
+
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(dashboard, ["list"])
+
+        assert result.exit_code == 0
+        assert "Total dashboards: 0" in result.output
+
+
+def test_dashboard_list_with_tags_filter(mock_client, runner):
+    """Test listing dashboards filtered by tags."""
+    mock_dashboards = [
+        MockDashboardSummary("abc-123", "Production Overview"),
+    ]
+    response = MockDashboardListResponse(mock_dashboards)
+    mock_client.dashboards.list_dashboards.return_value = response
+
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(dashboard, ["list", "--tags", "env:prod"])
+
+        assert result.exit_code == 0
+        mock_client.dashboards.list_dashboards.assert_called_once()
+        call_kwargs = mock_client.dashboards.list_dashboards.call_args
+        assert call_kwargs[1].get("filter_shared") is None or True
+        # The filter_configured is passed as kwarg
+        assert "filter_configured" in call_kwargs[1]
+
+
+# ============================================================================
+# Dashboard Get Command Tests
+# ============================================================================
+
+
+def test_dashboard_get_table_format(mock_client, runner):
+    """Test getting a dashboard with table format."""
+    mock_dash = MockDashboard(
+        "abc-123",
+        "Production Overview",
+        "ordered",
+        description="Main production dashboard",
+        author_handle="admin@example.com",
+    )
+    mock_client.dashboards.get_dashboard.return_value = mock_dash
+
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(dashboard, ["get", "abc-123"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "abc-123" in result.output
+        assert "Production Overview" in result.output
+        assert "ordered" in result.output
+        assert "Main production dashboard" in result.output
+        mock_client.dashboards.get_dashboard.assert_called_once_with("abc-123")
+
+
+def test_dashboard_get_json_format(mock_client, runner):
+    """Test getting a dashboard with JSON format."""
+    mock_dash = MockDashboard("def-456", "Staging Metrics", "free")
+    mock_client.dashboards.get_dashboard.return_value = mock_dash
+
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(dashboard, ["get", "def-456", "--format", "json"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["id"] == "def-456"
+        assert output["title"] == "Staging Metrics"
+        assert output["layout_type"] == "free"
+
+
+# ============================================================================
+# Dashboard Create Command Tests
+# ============================================================================
+
+
+def test_dashboard_create_from_file(mock_client, runner, tmp_path):
+    """Test creating a dashboard from a JSON file."""
+    dashboard_def = {
+        "title": "New Dashboard",
+        "layout_type": "ordered",
+        "widgets": [{"definition": {"type": "timeseries"}}],
+    }
+    json_file = tmp_path / "dashboard.json"
+    json_file.write_text(json.dumps(dashboard_def))
+
+    created = MockDashboard("new-123", "New Dashboard")
+    mock_client.dashboards.create_dashboard.return_value = created
+
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(dashboard, ["create", "-f", str(json_file)])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "new-123" in result.output
+        assert "created" in result.output.lower()
+        mock_client.dashboards.create_dashboard.assert_called_once()
+
+
+def test_dashboard_create_with_inline_flags(mock_client, runner):
+    """Test creating a dashboard with inline flags (metadata only)."""
+    created = MockDashboard("inline-123", "My Dashboard", "ordered")
+    mock_client.dashboards.create_dashboard.return_value = created
+
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            dashboard,
+            [
+                "create",
+                "--title",
+                "My Dashboard",
+                "--layout-type",
+                "ordered",
+                "--description",
+                "A test dashboard",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "inline-123" in result.output
+        assert "created" in result.output.lower()
+        mock_client.dashboards.create_dashboard.assert_called_once()
+
+
+def test_dashboard_create_missing_required(mock_client, runner):
+    """Test that create fails when no file and no title provided."""
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(dashboard, ["create"])
+
+        assert result.exit_code != 0
+
+
+def test_dashboard_create_from_file_overrides_flags(mock_client, runner, tmp_path):
+    """Test that -f flag takes precedence over inline flags."""
+    dashboard_def = {
+        "title": "From File",
+        "layout_type": "free",
+        "widgets": [],
+    }
+    json_file = tmp_path / "dashboard.json"
+    json_file.write_text(json.dumps(dashboard_def))
+
+    created = MockDashboard("file-123", "From File", "free")
+    mock_client.dashboards.create_dashboard.return_value = created
+
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            dashboard,
+            ["create", "-f", str(json_file), "--title", "Ignored Title"],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        # Verify the file data was used
+        call_kwargs = mock_client.dashboards.create_dashboard.call_args
+        body = call_kwargs[1]["body"]
+        assert body["title"] == "From File"
+
+
+def test_dashboard_create_from_invalid_file(mock_client, runner, tmp_path):
+    """Test creating a dashboard from an invalid JSON file."""
+    json_file = tmp_path / "bad.json"
+    json_file.write_text("not valid json {{{")
+
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(dashboard, ["create", "-f", str(json_file)])
+
+        assert result.exit_code != 0
+
+
+def test_dashboard_create_json_output(mock_client, runner):
+    """Test creating a dashboard with JSON output."""
+    created = MockDashboard("json-123", "JSON Dashboard")
+    mock_client.dashboards.create_dashboard.return_value = created
+
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            dashboard,
+            [
+                "create",
+                "--title",
+                "JSON Dashboard",
+                "--layout-type",
+                "ordered",
+                "--format",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["id"] == "json-123"
+        assert output["title"] == "JSON Dashboard"
+
+
+# ============================================================================
+# Dashboard Update Command Tests
+# ============================================================================
+
+
+def test_dashboard_update_from_file(mock_client, runner, tmp_path):
+    """Test updating a dashboard from a JSON file."""
+    dashboard_def = {
+        "title": "Updated Dashboard",
+        "layout_type": "ordered",
+        "widgets": [{"definition": {"type": "query_value"}}],
+    }
+    json_file = tmp_path / "update.json"
+    json_file.write_text(json.dumps(dashboard_def))
+
+    updated = MockDashboard("abc-123", "Updated Dashboard")
+    mock_client.dashboards.update_dashboard.return_value = updated
+
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(dashboard, ["update", "abc-123", "-f", str(json_file)])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "abc-123" in result.output
+        assert "updated" in result.output.lower()
+        mock_client.dashboards.update_dashboard.assert_called_once()
+        call_args = mock_client.dashboards.update_dashboard.call_args
+        assert call_args[0][0] == "abc-123"
+
+
+def test_dashboard_update_missing_file(mock_client, runner):
+    """Test that update fails when no file is provided."""
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(dashboard, ["update", "abc-123"])
+
+        assert result.exit_code != 0
+
+
+def test_dashboard_update_json_output(mock_client, runner, tmp_path):
+    """Test updating a dashboard with JSON output."""
+    dashboard_def = {"title": "Updated", "layout_type": "ordered", "widgets": []}
+    json_file = tmp_path / "update.json"
+    json_file.write_text(json.dumps(dashboard_def))
+
+    updated = MockDashboard("abc-123", "Updated")
+    mock_client.dashboards.update_dashboard.return_value = updated
+
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            dashboard, ["update", "abc-123", "-f", str(json_file), "--format", "json"]
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["id"] == "abc-123"
+
+
+# ============================================================================
+# Dashboard Delete Command Tests
+# ============================================================================
+
+
+def test_dashboard_delete_with_confirm_flag(mock_client, runner):
+    """Test deleting a dashboard with --confirm flag (no prompt)."""
+    mock_client.dashboards.delete_dashboard.return_value = Mock()
+
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(dashboard, ["delete", "abc-123", "--confirm"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "abc-123" in result.output
+        assert "deleted" in result.output.lower()
+        mock_client.dashboards.delete_dashboard.assert_called_once_with("abc-123")
+
+
+def test_dashboard_delete_interactive_confirm_yes(mock_client, runner):
+    """Test deleting a dashboard with interactive confirmation (user says yes)."""
+    mock_client.dashboards.delete_dashboard.return_value = Mock()
+
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(dashboard, ["delete", "abc-123"], input="y\n")
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "deleted" in result.output.lower()
+        mock_client.dashboards.delete_dashboard.assert_called_once_with("abc-123")
+
+
+def test_dashboard_delete_interactive_confirm_no(mock_client, runner):
+    """Test deleting a dashboard with interactive confirmation (user says no)."""
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(dashboard, ["delete", "abc-123"], input="n\n")
+
+        assert result.exit_code == 0
+        assert "Aborted" in result.output
+        mock_client.dashboards.delete_dashboard.assert_not_called()
+
+
+# ============================================================================
+# Dashboard Export Command Tests
+# ============================================================================
+
+
+def test_dashboard_export(mock_client, runner, tmp_path):
+    """Test exporting a dashboard to a JSON file."""
+    mock_dash = MockDashboard(
+        "abc-123",
+        "Production Overview",
+        "ordered",
+        widgets=[{"definition": {"type": "timeseries"}}],
+    )
+    mock_client.dashboards.get_dashboard.return_value = mock_dash
+
+    output_file = tmp_path / "exported.json"
+
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(dashboard, ["export", "abc-123", "-o", str(output_file)])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "exported" in result.output.lower()
+        mock_client.dashboards.get_dashboard.assert_called_once_with("abc-123")
+
+        # Verify file was written
+        assert output_file.exists()
+        exported = json.loads(output_file.read_text())
+        assert exported["title"] == "Production Overview"
+        assert exported["layout_type"] == "ordered"
+
+
+def test_dashboard_export_missing_output(mock_client, runner):
+    """Test that export fails when -o is not provided."""
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(dashboard, ["export", "abc-123"])
+
+        assert result.exit_code != 0
+
+
+# ============================================================================
+# Dashboard Clone Command Tests
+# ============================================================================
+
+
+def test_dashboard_clone(mock_client, runner):
+    """Test cloning a dashboard with a new title."""
+    # Setup: get returns the original dashboard
+    original = MockDashboard(
+        "abc-123",
+        "Production Overview",
+        "ordered",
+        description="Original description",
+        widgets=[{"definition": {"type": "timeseries"}}],
+    )
+    mock_client.dashboards.get_dashboard.return_value = original
+
+    # Setup: create returns the cloned dashboard
+    cloned = MockDashboard("cloned-456", "Copy of Production Overview")
+    mock_client.dashboards.create_dashboard.return_value = cloned
+
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            dashboard, ["clone", "abc-123", "--title", "Copy of Production Overview"]
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "cloned-456" in result.output
+        assert "cloned" in result.output.lower()
+
+        # Verify get was called to fetch original
+        mock_client.dashboards.get_dashboard.assert_called_once_with("abc-123")
+
+        # Verify create was called with the new title
+        mock_client.dashboards.create_dashboard.assert_called_once()
+        call_kwargs = mock_client.dashboards.create_dashboard.call_args
+        body = call_kwargs[1]["body"]
+        assert body["title"] == "Copy of Production Overview"
+
+
+def test_dashboard_clone_missing_title(mock_client, runner):
+    """Test that clone fails when --title is not provided."""
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(dashboard, ["clone", "abc-123"])
+
+        assert result.exit_code != 0
+
+
+def test_dashboard_clone_json_output(mock_client, runner):
+    """Test cloning a dashboard with JSON output."""
+    original = MockDashboard(
+        "abc-123",
+        "Original",
+        "ordered",
+        widgets=[{"definition": {"type": "timeseries"}}],
+    )
+    mock_client.dashboards.get_dashboard.return_value = original
+
+    cloned = MockDashboard("cloned-789", "Cloned Dashboard")
+    mock_client.dashboards.create_dashboard.return_value = cloned
+
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            dashboard,
+            ["clone", "abc-123", "--title", "Cloned Dashboard", "--format", "json"],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["id"] == "cloned-789"
+        assert output["title"] == "Cloned Dashboard"
+
+
+# ============================================================================
+# Edge Cases & Integration Tests
+# ============================================================================
+
+
+def test_dashboard_list_then_get_workflow(mock_client, runner):
+    """Test workflow: list dashboards, then get details of one."""
+    # Setup list
+    mock_dashboards = [
+        MockDashboardSummary("abc-123", "Dashboard A"),
+        MockDashboardSummary("def-456", "Dashboard B"),
+    ]
+    response = MockDashboardListResponse(mock_dashboards)
+    mock_client.dashboards.list_dashboards.return_value = response
+
+    # Setup get
+    mock_dash = MockDashboard("abc-123", "Dashboard A", "ordered")
+    mock_client.dashboards.get_dashboard.return_value = mock_dash
+
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        # List dashboards
+        result = runner.invoke(dashboard, ["list", "--format", "json"])
+        assert result.exit_code == 0
+        dashboards_list = json.loads(result.output)
+        assert len(dashboards_list) == 2
+
+        # Get details of the first one
+        result = runner.invoke(dashboard, ["get", "abc-123", "--format", "json"])
+        assert result.exit_code == 0
+        dash_details = json.loads(result.output)
+        assert dash_details["id"] == "abc-123"
+
+
+def test_dashboard_export_modify_update_workflow(mock_client, runner, tmp_path):
+    """Test GitOps workflow: export -> modify -> update."""
+    # Export
+    original = MockDashboard(
+        "abc-123",
+        "Original Title",
+        "ordered",
+        widgets=[{"definition": {"type": "timeseries"}}],
+    )
+    mock_client.dashboards.get_dashboard.return_value = original
+
+    export_file = tmp_path / "dashboard.json"
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(dashboard, ["export", "abc-123", "-o", str(export_file)])
+        assert result.exit_code == 0
+
+    # Modify the exported file
+    data = json.loads(export_file.read_text())
+    data["title"] = "Modified Title"
+    export_file.write_text(json.dumps(data))
+
+    # Update
+    updated = MockDashboard("abc-123", "Modified Title")
+    mock_client.dashboards.update_dashboard.return_value = updated
+
+    with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(dashboard, ["update", "abc-123", "-f", str(export_file)])
+        assert result.exit_code == 0
+        assert "updated" in result.output.lower()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ def mock_client():
     client.service_checks = Mock()
     client.downtimes = Mock()
     client.slos = Mock()
+    client.dashboards = Mock()
     return client
 
 


### PR DESCRIPTION
### **User description**
## Summary
- Add `dashboard` command group with `list`, `get`, `create`, `update`, `delete`, `export`, and `clone` subcommands
- Add `DashboardsApi` (v1 SDK) to `DatadogClient` in `client.py`
- Register `dashboard` command group in CLI entry point
- Add `client.dashboards` mock to shared test fixture
- Full TDD test coverage (25 tests) following existing patterns

## Test plan
- [x] All 343 tests pass (`uv run pytest tests/ -v`)
- [x] Black formatting passes (`uv run black --check ddogctl/ tests/`)
- [x] Ruff linting passes (`uv run ruff check ddogctl/ tests/`)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `dashboard` command group with 7 subcommands (list, get, create, update, delete, export, clone)

- Integrate `DashboardsApi` from Datadog SDK into `DatadogClient`

- Register dashboard commands in CLI entry point

- Comprehensive test coverage with 25 tests covering all commands and workflows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["CLI Entry Point"]
  DashCmd["Dashboard Command Group"]
  List["list<br/>table/JSON"]
  Get["get<br/>by ID"]
  Create["create<br/>file/flags"]
  Update["update<br/>from file"]
  Delete["delete<br/>confirm"]
  Export["export<br/>to file"]
  Clone["clone<br/>new title"]
  DashAPI["DashboardsApi<br/>SDK"]
  
  CLI -->|import| DashCmd
  DashCmd -->|subcommand| List
  DashCmd -->|subcommand| Get
  DashCmd -->|subcommand| Create
  DashCmd -->|subcommand| Update
  DashCmd -->|subcommand| Delete
  DashCmd -->|subcommand| Export
  DashCmd -->|subcommand| Clone
  
  List -->|calls| DashAPI
  Get -->|calls| DashAPI
  Create -->|calls| DashAPI
  Update -->|calls| DashAPI
  Delete -->|calls| DashAPI
  Export -->|calls| DashAPI
  Clone -->|calls| DashAPI
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.py</strong><dd><code>Register dashboard command group in CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/cli.py

<ul><li>Import <code>dashboard</code> command group from new module<br> <li> Register <code>dashboard</code> command with CLI main group</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/17/files#diff-1ca1a58dd47b18afff9b729ec6430c335581acb24899da2e49951588191ea17e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Add DashboardsApi to DatadogClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/client.py

<ul><li>Import <code>dashboards_api</code> from Datadog SDK v1 API<br> <li> Initialize <code>DashboardsApi</code> instance as <code>self.dashboards</code> in <code>DatadogClient</code></ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/17/files#diff-4e22d74821607a2dc683b1c483fe0aa643ff5dc3aab9f76c1e5b4373c0f6bf57">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dashboard.py</strong><dd><code>Add complete dashboard management command suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/commands/dashboard.py

<ul><li>Implement <code>list</code> command with table/JSON output and tag filtering<br> <li> Implement <code>get</code> command to retrieve dashboard details by ID<br> <li> Implement <code>create</code> command supporting JSON file input or inline flags <br>(title, layout-type, description)<br> <li> Implement <code>update</code> command to modify dashboards from JSON file<br> <li> Implement <code>delete</code> command with interactive confirmation<br> <li> Implement <code>export</code> command to save dashboard to JSON file<br> <li> Implement <code>clone</code> command to duplicate dashboard with new title<br> <li> All commands include error handling, status indicators, and formatted <br>output</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/17/files#diff-3f82f2f688d03a855f6a60379cef8933e532fd38c9ef433a045de828eba02641">+291/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_dashboard.py</strong><dd><code>Add comprehensive dashboard command tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/commands/test_dashboard.py

<ul><li>Create mock classes for dashboard objects (MockDashboard, <br>MockDashboardSummary, MockDashboardListResponse)<br> <li> Test list command with table/JSON formats, empty results, and tag <br>filtering<br> <li> Test get command with table/JSON formats<br> <li> Test create command from file, inline flags, missing required options, <br>file precedence, invalid JSON, and JSON output<br> <li> Test update command from file, missing file validation, and JSON <br>output<br> <li> Test delete command with confirm flag and interactive confirmation <br>(yes/no)<br> <li> Test export command and missing output validation<br> <li> Test clone command with title requirement, JSON output, and field <br>cleanup<br> <li> Test end-to-end workflows (list→get, export→modify→update)</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/17/files#diff-d87699dace447c410171c8edd54cd92b4fbcfeda3700ed4cdc54bdc77d132d0c">+613/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Add dashboards mock to test fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/conftest.py

<ul><li>Add <code>client.dashboards</code> mock to shared test fixture for use across test <br>suite</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/17/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

