### PR TITLE
feat(cli): add shell completion and command aliases

### DIFF
--- a/ddogctl/commands/completion.py
+++ b/ddogctl/commands/completion.py
@@ -1,0 +1,37 @@
+"""Shell completion commands."""
+
+import click
+
+
+@click.group(invoke_without_command=True)
+@click.pass_context
+def completion(ctx):
+    """Generate shell completion scripts.
+
+    Output shell-specific completion scripts for bash, zsh, or fish.
+
+    Usage:
+        eval "$(ddogctl completion bash)"
+        eval "$(ddogctl completion zsh)"
+        ddogctl completion fish | source
+    """
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@completion.command()
+def bash():
+    """Output bash completion script."""
+    click.echo('eval "$(_DDOGCTL_COMPLETE=bash_source ddogctl)"')
+
+
+@completion.command()
+def zsh():
+    """Output zsh completion script."""
+    click.echo('eval "$(_DDOGCTL_COMPLETE=zsh_source ddogctl)"')
+
+
+@completion.command()
+def fish():
+    """Output fish completion script."""
+    click.echo("_DDOGCTL_COMPLETE=fish_source ddogctl | source")

--- a/tests/commands/test_completion.py
+++ b/tests/commands/test_completion.py
@@ -1,0 +1,74 @@
+"""Tests for completion commands."""
+
+from click.testing import CliRunner
+from ddogctl.cli import main
+
+
+class TestCompletionBash:
+    """Tests for bash completion output."""
+
+    def test_bash_outputs_completion_script(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["completion", "bash"])
+        assert result.exit_code == 0
+        assert "_DDOGCTL_COMPLETE=bash_source" in result.output
+        assert "ddogctl" in result.output
+
+    def test_bash_outputs_eval_wrapper(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["completion", "bash"])
+        assert result.exit_code == 0
+        assert "eval" in result.output
+
+
+class TestCompletionZsh:
+    """Tests for zsh completion output."""
+
+    def test_zsh_outputs_completion_script(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["completion", "zsh"])
+        assert result.exit_code == 0
+        assert "_DDOGCTL_COMPLETE=zsh_source" in result.output
+        assert "ddogctl" in result.output
+
+    def test_zsh_outputs_eval_wrapper(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["completion", "zsh"])
+        assert result.exit_code == 0
+        assert "eval" in result.output
+
+
+class TestCompletionFish:
+    """Tests for fish completion output."""
+
+    def test_fish_outputs_completion_script(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["completion", "fish"])
+        assert result.exit_code == 0
+        assert "_DDOGCTL_COMPLETE=fish_source" in result.output
+        assert "ddogctl" in result.output
+
+    def test_fish_outputs_source_pipe(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["completion", "fish"])
+        assert result.exit_code == 0
+        assert "source" in result.output
+
+
+class TestCompletionGroup:
+    """Tests for the completion group itself."""
+
+    def test_completion_help(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["completion", "--help"])
+        assert result.exit_code == 0
+        assert "completion" in result.output.lower()
+
+    def test_completion_no_args_shows_help(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["completion"])
+        assert result.exit_code == 0
+        # Should show available subcommands
+        assert "bash" in result.output
+        assert "zsh" in result.output
+        assert "fish" in result.output

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -1,0 +1,105 @@
+"""Tests for command aliases."""
+
+from unittest.mock import patch, Mock
+from click.testing import CliRunner
+from ddogctl.cli import main
+
+
+class TestAliasResolution:
+    """Tests that short aliases resolve to full command groups."""
+
+    def test_mon_resolves_to_monitor(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["mon", "--help"])
+        assert result.exit_code == 0
+        # Should show monitor group help
+        assert "monitor" in result.output.lower() or "Monitor" in result.output
+
+    def test_dash_resolves_to_dashboard(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["dash", "--help"])
+        assert result.exit_code == 0
+        assert "dashboard" in result.output.lower() or "Dashboard" in result.output
+
+    def test_dt_resolves_to_downtime(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["dt", "--help"])
+        assert result.exit_code == 0
+        assert "downtime" in result.output.lower() or "Downtime" in result.output
+
+    def test_sc_resolves_to_service_check(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["sc", "--help"])
+        assert result.exit_code == 0
+        assert "service" in result.output.lower() or "Service" in result.output
+
+    def test_inv_resolves_to_investigate(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["inv", "--help"])
+        assert result.exit_code == 0
+        assert "investigate" in result.output.lower() or "Investigate" in result.output
+
+
+class TestAliasSubcommands:
+    """Tests that aliases work with subcommands."""
+
+    def test_mon_list_works(self):
+        """mon list should invoke monitor list."""
+        runner = CliRunner()
+        with patch("ddogctl.commands.monitor.get_datadog_client") as mock_get:
+            mock_client = Mock()
+            mock_client.monitors = Mock()
+            mock_client.monitors.list_monitors.return_value = []
+            mock_get.return_value = mock_client
+            result = runner.invoke(main, ["mon", "list"])
+            assert result.exit_code == 0
+
+    def test_inv_with_subcommand(self):
+        """inv should accept investigate subcommands."""
+        runner = CliRunner()
+        # Just verify the alias resolves and the subcommand help is accessible
+        result = runner.invoke(main, ["inv", "latency", "--help"])
+        assert result.exit_code == 0
+
+
+class TestFullCommandsStillWork:
+    """Tests that full command names still work alongside aliases."""
+
+    def test_monitor_still_works(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["monitor", "--help"])
+        assert result.exit_code == 0
+
+    def test_dashboard_still_works(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["dashboard", "--help"])
+        assert result.exit_code == 0
+
+    def test_downtime_still_works(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["downtime", "--help"])
+        assert result.exit_code == 0
+
+    def test_service_check_still_works(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["service-check", "--help"])
+        assert result.exit_code == 0
+
+    def test_investigate_still_works(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["investigate", "--help"])
+        assert result.exit_code == 0
+
+
+class TestUnknownCommand:
+    """Tests that unknown commands still fail properly."""
+
+    def test_unknown_command_fails(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["nonexistent"])
+        assert result.exit_code != 0
+
+    def test_unknown_alias_fails(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["xyz"])
+        assert result.exit_code != 0


### PR DESCRIPTION
### **User description**
## Summary
- Add `completion` command group for bash, zsh, fish shell completion scripts
- Add command aliases: mon=monitor, dash=dashboard, dt=downtime, sc=service-check, inv=investigate
- Use custom AliasGroup for transparent alias resolution
- Full TDD test coverage (22 new tests)

## Test plan
- [x] All 431 tests pass
- [x] Black formatting passes
- [x] Ruff linting passes


___

### **PR Type**
Enhancement


___

### **Description**
- Add shell completion command group for bash, zsh, fish shells

- Implement command aliases for shorter command names

- Create AliasGroup class for transparent alias resolution

- Add comprehensive test coverage for aliases and completion


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["CLI Main Entry"]
  AG["AliasGroup Class"]
  ALIASES["Aliases Map"]
  COMP["Completion Command"]
  BASH["Bash Completion"]
  ZSH["Zsh Completion"]
  FISH["Fish Completion"]
  
  CLI -- "uses" --> AG
  AG -- "resolves" --> ALIASES
  CLI -- "registers" --> COMP
  COMP -- "provides" --> BASH
  COMP -- "provides" --> ZSH
  COMP -- "provides" --> FISH
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.py</strong><dd><code>Add alias resolution and completion command registration</code>&nbsp; </dd></summary>
<hr>

ddogctl/cli.py

<ul><li>Add ALIASES dictionary mapping short names to full command names<br> <li> Implement AliasGroup class extending click.Group for alias resolution<br> <li> Update main decorator to use AliasGroup class<br> <li> Import and register completion command</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/18/files#diff-1ca1a58dd47b18afff9b729ec6430c335581acb24899da2e49951588191ea17e">+32/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>completion.py</strong><dd><code>Implement shell completion command group</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/commands/completion.py

<ul><li>Create completion command group with invoke_without_command support<br> <li> Implement bash subcommand outputting bash completion script<br> <li> Implement zsh subcommand outputting zsh completion script<br> <li> Implement fish subcommand outputting fish completion script</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/18/files#diff-8c57679565b73a04cfeed0ab5565c21625829fa0ec3d35bfe185c262f1d60380">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_completion.py</strong><dd><code>Add comprehensive completion command tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/commands/test_completion.py

<ul><li>Add TestCompletionBash class with 2 tests for bash completion output<br> <li> Add TestCompletionZsh class with 2 tests for zsh completion output<br> <li> Add TestCompletionFish class with 2 tests for fish completion output<br> <li> Add TestCompletionGroup class with 2 tests for completion group <br>behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/18/files#diff-3aa34df50d6878bbb2471e2dc35d78407afb27f5f9282abff59b60b28ce0276f">+74/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_aliases.py</strong><dd><code>Add comprehensive command alias tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_aliases.py

<ul><li>Add TestAliasResolution class with 5 tests for alias-to-command <br>mapping<br> <li> Add TestAliasSubcommands class with 2 tests for alias subcommand <br>execution<br> <li> Add TestFullCommandsStillWork class with 5 tests for backward <br>compatibility<br> <li> Add TestUnknownCommand class with 2 tests for error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/18/files#diff-2a40e48cc123b0a68492ff2c6e69727fd9fdd5fecb4d0ce207d9903dc0094a05">+105/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

