### PR TITLE
feat(apply): add apply and diff commands for GitOps workflows

### DIFF
--- a/ddogctl/cli.py
+++ b/ddogctl/cli.py
@@ -72,6 +72,7 @@ from ddogctl.commands.downtime import downtime
 from ddogctl.commands.slo import slo
 from ddogctl.commands.dashboard import dashboard
 from ddogctl.commands.completion import completion
+from ddogctl.commands.apply import apply_cmd, diff_cmd
 
 main.add_command(monitor)
 main.add_command(metric)
@@ -87,6 +88,8 @@ main.add_command(downtime)
 main.add_command(slo)
 main.add_command(dashboard)
 main.add_command(completion)
+main.add_command(apply_cmd)
+main.add_command(diff_cmd)
 
 
 if __name__ == "__main__":

--- a/ddogctl/commands/apply.py
+++ b/ddogctl/commands/apply.py
@@ -1,0 +1,272 @@
+"""Apply and diff commands for declarative resource management."""
+
+import difflib
+import json
+import sys
+from pathlib import Path
+
+import click
+from rich.console import Console
+from rich.syntax import Syntax
+
+from ddogctl.client import get_datadog_client
+from ddogctl.utils.error import handle_api_error
+from ddogctl.utils.file_input import load_json_file
+
+console = Console()
+
+
+def detect_resource_type(data: dict) -> str:
+    """Detect Datadog resource type from JSON structure.
+
+    Detection priority:
+        1. dashboard — has "layout_type" or "widgets"
+        2. slo — has "thresholds" and type is "metric" or "monitor"
+        3. downtime — has "scope" as a list
+        4. monitor — has "query"
+
+    Args:
+        data: Parsed JSON dict representing a Datadog resource.
+
+    Returns:
+        Resource type string: "monitor", "dashboard", "slo", or "downtime".
+
+    Raises:
+        ValueError: If the resource type cannot be determined.
+    """
+    if "layout_type" in data or "widgets" in data:
+        return "dashboard"
+    if "thresholds" in data and data.get("type") in ("metric", "monitor"):
+        return "slo"
+    if isinstance(data.get("scope"), list):
+        return "downtime"
+    if "query" in data:
+        return "monitor"
+    raise ValueError("Cannot detect resource type from JSON structure")
+
+
+def _apply_single_resource(data: dict, dry_run: bool = False) -> None:
+    """Apply a single resource (create or update).
+
+    Args:
+        data: Parsed JSON dict representing a Datadog resource.
+        dry_run: If True, preview without making API calls.
+    """
+    resource_type = detect_resource_type(data)
+    has_id = "id" in data
+    action = "update" if has_id else "create"
+
+    if dry_run:
+        console.print(f"[yellow]DRY RUN: Would {action} {resource_type}[/yellow]")
+        if has_id:
+            console.print(f"[dim]  ID: {data['id']}[/dim]")
+        console.print(f"[dim]  Data: {json.dumps(data, indent=2, default=str)[:200]}...[/dim]")
+        return
+
+    client = get_datadog_client()
+
+    if resource_type == "monitor":
+        if action == "create":
+            result = client.monitors.create_monitor(body=data)
+        else:
+            monitor_id = data.pop("id")
+            result = client.monitors.update_monitor(monitor_id, body=data)
+        console.print(f"[green]{action.title()}d monitor {result.id}[/green]")
+
+    elif resource_type == "dashboard":
+        if action == "create":
+            result = client.dashboards.create_dashboard(body=data)
+        else:
+            dashboard_id = data.pop("id")
+            result = client.dashboards.update_dashboard(dashboard_id, body=data)
+        console.print(f"[green]{action.title()}d dashboard {result.id}[/green]")
+
+    elif resource_type == "slo":
+        if action == "create":
+            result = client.slos.create_slo(body=data)
+            slo_obj = result.data[0] if result.data else None
+            slo_id = slo_obj.id if slo_obj else "unknown"
+        else:
+            slo_id = data.pop("id")
+            result = client.slos.update_slo(slo_id, body=data)
+        console.print(f"[green]{action.title()}d slo {slo_id}[/green]")
+
+    elif resource_type == "downtime":
+        if action == "create":
+            result = client.downtimes.create_downtime(body=data)
+        else:
+            downtime_id = data.pop("id")
+            result = client.downtimes.update_downtime(downtime_id, body=data)
+        console.print(f"[green]{action.title()}d downtime {result.id}[/green]")
+
+
+def _fetch_live_state(data: dict, resource_type: str) -> dict:
+    """Fetch the live state of a resource from the Datadog API.
+
+    Args:
+        data: Local resource data (must contain "id").
+        resource_type: The detected resource type.
+
+    Returns:
+        Dict representation of the live resource.
+    """
+    client = get_datadog_client()
+    resource_id = data["id"]
+
+    if resource_type == "monitor":
+        live = client.monitors.get_monitor(resource_id)
+        return live.to_dict()
+    elif resource_type == "dashboard":
+        live = client.dashboards.get_dashboard(resource_id)
+        return live.to_dict()
+    elif resource_type == "slo":
+        response = client.slos.get_slo(resource_id)
+        return response.data.to_dict()
+    elif resource_type == "downtime":
+        live = client.downtimes.get_downtime(resource_id)
+        return live.to_dict()
+    else:
+        raise ValueError(f"Unknown resource type: {resource_type}")
+
+
+@click.command(name="apply")
+@click.option(
+    "-f",
+    "--file",
+    "file_path",
+    required=True,
+    help="JSON file or directory to apply",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Preview changes without applying",
+)
+@click.option(
+    "--recursive",
+    is_flag=True,
+    default=False,
+    help="Scan directory recursively for JSON files",
+)
+@handle_api_error
+def apply_cmd(file_path, dry_run, recursive):
+    """Apply Datadog resources from JSON files.
+
+    Auto-detects resource type (monitor, dashboard, SLO, downtime) from JSON
+    structure. Resources with an 'id' field are updated; without are created.
+
+    Examples:
+        ddogctl apply -f monitor.json
+        ddogctl apply -f dashboards/ --recursive
+        ddogctl apply -f slo.json --dry-run
+    """
+    path = Path(file_path)
+
+    if path.is_dir():
+        if not recursive:
+            console.print(
+                f"[red]Error: '{file_path}' is a directory. Use --recursive to scan it.[/red]"
+            )
+            sys.exit(1)
+
+        json_files = sorted(path.glob("**/*.json"))
+        if not json_files:
+            console.print(f"[yellow]No JSON files found in {file_path}[/yellow]")
+            sys.exit(1)
+
+        console.print(f"[cyan]Found {len(json_files)} JSON file(s) in {file_path}[/cyan]")
+        for jf in json_files:
+            console.print(f"\n[bold]Processing {jf.name}...[/bold]")
+            try:
+                data = load_json_file(str(jf))
+                _apply_single_resource(data, dry_run=dry_run)
+            except (ValueError, FileNotFoundError) as e:
+                console.print(f"[red]Error processing {jf.name}: {e}[/red]")
+
+    elif path.is_file():
+        try:
+            data = load_json_file(file_path)
+        except FileNotFoundError:
+            console.print(f"[red]Error: File not found: {file_path}[/red]")
+            sys.exit(1)
+        except ValueError as e:
+            console.print(f"[red]Error: {e}[/red]")
+            sys.exit(1)
+
+        try:
+            _apply_single_resource(data, dry_run=dry_run)
+        except ValueError as e:
+            console.print(f"[red]Error: {e}[/red]")
+            sys.exit(1)
+
+    else:
+        console.print(f"[red]Error: File not found: {file_path}[/red]")
+        sys.exit(1)
+
+
+@click.command(name="diff")
+@click.option(
+    "-f",
+    "--file",
+    "file_path",
+    required=True,
+    help="JSON file to compare against live state",
+)
+@handle_api_error
+def diff_cmd(file_path):
+    """Compare a local JSON file against the live Datadog state.
+
+    The file must contain an 'id' field so the live resource can be fetched.
+    Shows a unified diff with color highlighting.
+
+    Examples:
+        ddogctl diff -f monitor.json
+        ddogctl diff -f dashboard.json
+    """
+    try:
+        local_data = load_json_file(file_path)
+    except FileNotFoundError:
+        console.print(f"[red]Error: File not found: {file_path}[/red]")
+        sys.exit(1)
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        sys.exit(1)
+
+    if "id" not in local_data:
+        console.print(
+            "[red]Error: File must contain an 'id' field to diff against live state[/red]"
+        )
+        sys.exit(1)
+
+    try:
+        resource_type = detect_resource_type(local_data)
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        sys.exit(1)
+
+    console.print(f"[cyan]Fetching live {resource_type} {local_data['id']}...[/cyan]")
+
+    live_data = _fetch_live_state(local_data, resource_type)
+
+    # Normalize both to sorted JSON for comparison
+    local_json = json.dumps(local_data, indent=2, sort_keys=True, default=str)
+    live_json = json.dumps(live_data, indent=2, sort_keys=True, default=str)
+
+    if local_json == live_json:
+        console.print("[green]No differences found. Local file is identical to live state.[/green]")
+        return
+
+    # Generate unified diff
+    diff_lines = list(
+        difflib.unified_diff(
+            live_json.splitlines(keepends=True),
+            local_json.splitlines(keepends=True),
+            fromfile=f"live ({resource_type} {local_data['id']})",
+            tofile=f"local ({file_path})",
+        )
+    )
+
+    diff_text = "".join(diff_lines)
+    syntax = Syntax(diff_text, "diff", theme="monokai", line_numbers=False)
+    console.print(syntax)

--- a/tests/commands/test_apply.py
+++ b/tests/commands/test_apply.py
@@ -1,0 +1,613 @@
+"""Tests for apply and diff commands."""
+
+import json
+import os
+import pytest
+from unittest.mock import Mock, patch
+from click.testing import CliRunner
+from ddogctl.commands.apply import apply_cmd, diff_cmd, detect_resource_type
+
+
+@pytest.fixture
+def mock_client():
+    """Create a mock Datadog client."""
+    client = Mock()
+    client.monitors = Mock()
+    client.dashboards = Mock()
+    client.slos = Mock()
+    client.downtimes = Mock()
+    return client
+
+
+@pytest.fixture
+def runner():
+    """Click CLI test runner."""
+    return CliRunner()
+
+
+# ============================================================================
+# detect_resource_type tests
+# ============================================================================
+
+
+class TestDetectResourceType:
+    """Tests for resource type auto-detection from JSON structure."""
+
+    def test_detect_monitor_with_query(self):
+        data = {"name": "CPU Alert", "type": "metric alert", "query": "avg:system.cpu{*} > 90"}
+        assert detect_resource_type(data) == "monitor"
+
+    def test_detect_dashboard_with_layout_type(self):
+        data = {"title": "My Dashboard", "layout_type": "ordered", "widgets": []}
+        assert detect_resource_type(data) == "dashboard"
+
+    def test_detect_dashboard_with_widgets_only(self):
+        data = {"title": "My Dashboard", "widgets": [{"type": "timeseries"}]}
+        assert detect_resource_type(data) == "dashboard"
+
+    def test_detect_slo_metric_type(self):
+        data = {
+            "name": "API Availability",
+            "type": "metric",
+            "thresholds": [{"timeframe": "30d", "target": 99.9}],
+        }
+        assert detect_resource_type(data) == "slo"
+
+    def test_detect_slo_monitor_type(self):
+        data = {
+            "name": "API Availability",
+            "type": "monitor",
+            "thresholds": [{"timeframe": "30d", "target": 99.9}],
+        }
+        assert detect_resource_type(data) == "slo"
+
+    def test_detect_downtime_with_scope_list(self):
+        data = {"scope": ["env:prod"], "message": "Scheduled maintenance"}
+        assert detect_resource_type(data) == "downtime"
+
+    def test_detect_downtime_scope_not_list_falls_through(self):
+        """scope as a string should not match downtime (must be a list)."""
+        data = {"scope": "env:prod", "query": "avg:system.cpu{*} > 90"}
+        assert detect_resource_type(data) == "monitor"
+
+    def test_detect_unknown_raises_error(self):
+        data = {"foo": "bar", "baz": 42}
+        with pytest.raises(ValueError, match="Cannot detect resource type"):
+            detect_resource_type(data)
+
+    def test_dashboard_takes_priority_over_monitor(self):
+        """If data has both layout_type and query, it should be detected as dashboard."""
+        data = {"layout_type": "ordered", "query": "something", "widgets": []}
+        assert detect_resource_type(data) == "dashboard"
+
+    def test_slo_takes_priority_over_monitor(self):
+        """SLO with type=metric and thresholds should win over monitor query detection."""
+        data = {
+            "type": "metric",
+            "thresholds": [{"timeframe": "30d", "target": 99.9}],
+            "query": {"numerator": "sum:requests.ok{*}", "denominator": "sum:requests{*}"},
+        }
+        assert detect_resource_type(data) == "slo"
+
+
+# ============================================================================
+# apply command tests
+# ============================================================================
+
+
+class TestApplyCommand:
+    """Tests for the apply command."""
+
+    def test_apply_requires_file_option(self, runner):
+        result = runner.invoke(apply_cmd, [])
+        assert result.exit_code != 0
+        assert "Missing option" in result.output or "required" in result.output.lower()
+
+    def test_apply_file_not_found(self, runner):
+        result = runner.invoke(apply_cmd, ["-f", "/nonexistent/file.json"])
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower() or "Error" in result.output
+
+    def test_apply_invalid_json(self, runner):
+        with runner.isolated_filesystem():
+            with open("bad.json", "w") as f:
+                f.write("not valid json{{{")
+            result = runner.invoke(apply_cmd, ["-f", "bad.json"])
+            assert result.exit_code != 0
+
+    def test_apply_unrecognized_resource(self, runner):
+        with runner.isolated_filesystem():
+            with open("unknown.json", "w") as f:
+                json.dump({"foo": "bar"}, f)
+            result = runner.invoke(apply_cmd, ["-f", "unknown.json"])
+            assert result.exit_code != 0
+            assert "Cannot detect resource type" in result.output
+
+    # --- Monitor apply ---
+
+    @patch("ddogctl.commands.apply.get_datadog_client")
+    def test_apply_create_monitor(self, mock_get_client, mock_client, runner):
+        mock_get_client.return_value = mock_client
+        created_monitor = Mock()
+        created_monitor.id = 12345
+        created_monitor.to_dict.return_value = {"id": 12345, "name": "CPU Alert"}
+        mock_client.monitors.create_monitor.return_value = created_monitor
+
+        monitor_data = {
+            "name": "CPU Alert",
+            "type": "metric alert",
+            "query": "avg:system.cpu{*} > 90",
+        }
+
+        with runner.isolated_filesystem():
+            with open("monitor.json", "w") as f:
+                json.dump(monitor_data, f)
+            result = runner.invoke(apply_cmd, ["-f", "monitor.json"])
+
+        assert result.exit_code == 0
+        assert "create" in result.output.lower()
+        assert "monitor" in result.output.lower()
+        assert "12345" in result.output
+        mock_client.monitors.create_monitor.assert_called_once()
+
+    @patch("ddogctl.commands.apply.get_datadog_client")
+    def test_apply_update_monitor(self, mock_get_client, mock_client, runner):
+        mock_get_client.return_value = mock_client
+        updated_monitor = Mock()
+        updated_monitor.id = 12345
+        updated_monitor.to_dict.return_value = {"id": 12345, "name": "CPU Alert Updated"}
+        mock_client.monitors.update_monitor.return_value = updated_monitor
+
+        monitor_data = {
+            "id": 12345,
+            "name": "CPU Alert Updated",
+            "type": "metric alert",
+            "query": "avg:system.cpu{*} > 95",
+        }
+
+        with runner.isolated_filesystem():
+            with open("monitor.json", "w") as f:
+                json.dump(monitor_data, f)
+            result = runner.invoke(apply_cmd, ["-f", "monitor.json"])
+
+        assert result.exit_code == 0
+        assert "update" in result.output.lower()
+        assert "monitor" in result.output.lower()
+        assert "12345" in result.output
+        mock_client.monitors.update_monitor.assert_called_once()
+
+    # --- Dashboard apply ---
+
+    @patch("ddogctl.commands.apply.get_datadog_client")
+    def test_apply_create_dashboard(self, mock_get_client, mock_client, runner):
+        mock_get_client.return_value = mock_client
+        created = Mock()
+        created.id = "abc-def-123"
+        created.to_dict.return_value = {"id": "abc-def-123", "title": "My Dashboard"}
+        mock_client.dashboards.create_dashboard.return_value = created
+
+        data = {"title": "My Dashboard", "layout_type": "ordered", "widgets": []}
+
+        with runner.isolated_filesystem():
+            with open("dash.json", "w") as f:
+                json.dump(data, f)
+            result = runner.invoke(apply_cmd, ["-f", "dash.json"])
+
+        assert result.exit_code == 0
+        assert "create" in result.output.lower()
+        assert "dashboard" in result.output.lower()
+        assert "abc-def-123" in result.output
+        mock_client.dashboards.create_dashboard.assert_called_once()
+
+    @patch("ddogctl.commands.apply.get_datadog_client")
+    def test_apply_update_dashboard(self, mock_get_client, mock_client, runner):
+        mock_get_client.return_value = mock_client
+        updated = Mock()
+        updated.id = "abc-def-123"
+        updated.to_dict.return_value = {"id": "abc-def-123", "title": "Updated"}
+        mock_client.dashboards.update_dashboard.return_value = updated
+
+        data = {"id": "abc-def-123", "title": "Updated", "layout_type": "ordered", "widgets": []}
+
+        with runner.isolated_filesystem():
+            with open("dash.json", "w") as f:
+                json.dump(data, f)
+            result = runner.invoke(apply_cmd, ["-f", "dash.json"])
+
+        assert result.exit_code == 0
+        assert "update" in result.output.lower()
+        assert "dashboard" in result.output.lower()
+        mock_client.dashboards.update_dashboard.assert_called_once()
+
+    # --- SLO apply ---
+
+    @patch("ddogctl.commands.apply.get_datadog_client")
+    def test_apply_create_slo(self, mock_get_client, mock_client, runner):
+        mock_get_client.return_value = mock_client
+        created = Mock()
+        created.id = "slo-abc123"
+        created.to_dict.return_value = {"id": "slo-abc123", "name": "API SLO"}
+        slo_response = Mock()
+        slo_response.data = [created]
+        mock_client.slos.create_slo.return_value = slo_response
+
+        data = {
+            "name": "API SLO",
+            "type": "metric",
+            "thresholds": [{"timeframe": "30d", "target": 99.9}],
+        }
+
+        with runner.isolated_filesystem():
+            with open("slo.json", "w") as f:
+                json.dump(data, f)
+            result = runner.invoke(apply_cmd, ["-f", "slo.json"])
+
+        assert result.exit_code == 0
+        assert "create" in result.output.lower()
+        assert "slo" in result.output.lower()
+        mock_client.slos.create_slo.assert_called_once()
+
+    @patch("ddogctl.commands.apply.get_datadog_client")
+    def test_apply_update_slo(self, mock_get_client, mock_client, runner):
+        mock_get_client.return_value = mock_client
+        updated = Mock()
+        updated.id = "slo-abc123"
+        updated.to_dict.return_value = {"id": "slo-abc123", "name": "API SLO"}
+        slo_response = Mock()
+        slo_response.data = [updated]
+        mock_client.slos.update_slo.return_value = slo_response
+
+        data = {
+            "id": "slo-abc123",
+            "name": "API SLO",
+            "type": "metric",
+            "thresholds": [{"timeframe": "30d", "target": 99.9}],
+        }
+
+        with runner.isolated_filesystem():
+            with open("slo.json", "w") as f:
+                json.dump(data, f)
+            result = runner.invoke(apply_cmd, ["-f", "slo.json"])
+
+        assert result.exit_code == 0
+        assert "update" in result.output.lower()
+        assert "slo" in result.output.lower()
+        mock_client.slos.update_slo.assert_called_once()
+
+    # --- Downtime apply ---
+
+    @patch("ddogctl.commands.apply.get_datadog_client")
+    def test_apply_create_downtime(self, mock_get_client, mock_client, runner):
+        mock_get_client.return_value = mock_client
+        created = Mock()
+        created.id = 9876
+        created.to_dict.return_value = {"id": 9876, "scope": ["env:prod"]}
+        mock_client.downtimes.create_downtime.return_value = created
+
+        data = {"scope": ["env:prod"], "message": "Maintenance window"}
+
+        with runner.isolated_filesystem():
+            with open("downtime.json", "w") as f:
+                json.dump(data, f)
+            result = runner.invoke(apply_cmd, ["-f", "downtime.json"])
+
+        assert result.exit_code == 0
+        assert "create" in result.output.lower()
+        assert "downtime" in result.output.lower()
+        mock_client.downtimes.create_downtime.assert_called_once()
+
+    @patch("ddogctl.commands.apply.get_datadog_client")
+    def test_apply_update_downtime(self, mock_get_client, mock_client, runner):
+        mock_get_client.return_value = mock_client
+        updated = Mock()
+        updated.id = 9876
+        updated.to_dict.return_value = {"id": 9876, "scope": ["env:prod"]}
+        mock_client.downtimes.update_downtime.return_value = updated
+
+        data = {"id": 9876, "scope": ["env:prod"], "message": "Extended maintenance"}
+
+        with runner.isolated_filesystem():
+            with open("downtime.json", "w") as f:
+                json.dump(data, f)
+            result = runner.invoke(apply_cmd, ["-f", "downtime.json"])
+
+        assert result.exit_code == 0
+        assert "update" in result.output.lower()
+        assert "downtime" in result.output.lower()
+        mock_client.downtimes.update_downtime.assert_called_once()
+
+    # --- Dry-run ---
+
+    def test_apply_dry_run_monitor_create(self, runner):
+        """Dry-run should NOT make API calls."""
+        data = {
+            "name": "CPU Alert",
+            "type": "metric alert",
+            "query": "avg:system.cpu{*} > 90",
+        }
+
+        with runner.isolated_filesystem():
+            with open("monitor.json", "w") as f:
+                json.dump(data, f)
+            result = runner.invoke(apply_cmd, ["-f", "monitor.json", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "DRY RUN" in result.output
+        assert "create" in result.output.lower()
+        assert "monitor" in result.output.lower()
+
+    def test_apply_dry_run_monitor_update(self, runner):
+        data = {
+            "id": 12345,
+            "name": "CPU Alert",
+            "type": "metric alert",
+            "query": "avg:system.cpu{*} > 90",
+        }
+
+        with runner.isolated_filesystem():
+            with open("monitor.json", "w") as f:
+                json.dump(data, f)
+            result = runner.invoke(apply_cmd, ["-f", "monitor.json", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "DRY RUN" in result.output
+        assert "update" in result.output.lower()
+        assert "12345" in result.output
+
+    def test_apply_dry_run_dashboard(self, runner):
+        data = {"title": "My Dashboard", "layout_type": "ordered", "widgets": []}
+
+        with runner.isolated_filesystem():
+            with open("dash.json", "w") as f:
+                json.dump(data, f)
+            result = runner.invoke(apply_cmd, ["-f", "dash.json", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "DRY RUN" in result.output
+        assert "dashboard" in result.output.lower()
+
+    # --- Recursive directory scanning ---
+
+    @patch("ddogctl.commands.apply.get_datadog_client")
+    def test_apply_recursive_directory(self, mock_get_client, mock_client, runner):
+        mock_get_client.return_value = mock_client
+
+        created_monitor = Mock()
+        created_monitor.id = 111
+        created_monitor.to_dict.return_value = {"id": 111}
+        mock_client.monitors.create_monitor.return_value = created_monitor
+
+        created_dash = Mock()
+        created_dash.id = "dash-abc"
+        created_dash.to_dict.return_value = {"id": "dash-abc"}
+        mock_client.dashboards.create_dashboard.return_value = created_dash
+
+        with runner.isolated_filesystem():
+            os.makedirs("resources")
+            with open("resources/monitor.json", "w") as f:
+                json.dump({"name": "Test", "type": "metric alert", "query": "avg:cpu{*} > 90"}, f)
+            with open("resources/dashboard.json", "w") as f:
+                json.dump({"title": "Dash", "layout_type": "ordered", "widgets": []}, f)
+            # Non-json file should be ignored
+            with open("resources/readme.txt", "w") as f:
+                f.write("not json")
+
+            result = runner.invoke(apply_cmd, ["-f", "resources", "--recursive"])
+
+        assert result.exit_code == 0
+        assert mock_client.monitors.create_monitor.called
+        assert mock_client.dashboards.create_dashboard.called
+
+    def test_apply_recursive_without_flag_on_directory(self, runner):
+        """Passing a directory without --recursive should error."""
+        with runner.isolated_filesystem():
+            os.makedirs("resources")
+            with open("resources/monitor.json", "w") as f:
+                json.dump({"name": "Test", "type": "metric alert", "query": "q"}, f)
+
+            result = runner.invoke(apply_cmd, ["-f", "resources"])
+
+        assert result.exit_code != 0
+
+    def test_apply_recursive_empty_directory(self, runner):
+        with runner.isolated_filesystem():
+            os.makedirs("empty_dir")
+            result = runner.invoke(apply_cmd, ["-f", "empty_dir", "--recursive"])
+
+        assert result.exit_code != 0 or "No JSON files" in result.output
+
+    def test_apply_recursive_dry_run(self, runner):
+        """Recursive + dry-run should list all files without API calls."""
+        with runner.isolated_filesystem():
+            os.makedirs("resources")
+            with open("resources/monitor.json", "w") as f:
+                json.dump({"name": "Test", "type": "metric alert", "query": "q"}, f)
+            with open("resources/dash.json", "w") as f:
+                json.dump({"title": "Dash", "layout_type": "ordered", "widgets": []}, f)
+
+            result = runner.invoke(apply_cmd, ["-f", "resources", "--recursive", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "DRY RUN" in result.output
+
+
+# ============================================================================
+# diff command tests
+# ============================================================================
+
+
+class TestDiffCommand:
+    """Tests for the diff command."""
+
+    def test_diff_requires_file_option(self, runner):
+        result = runner.invoke(diff_cmd, [])
+        assert result.exit_code != 0
+
+    def test_diff_file_not_found(self, runner):
+        result = runner.invoke(diff_cmd, ["-f", "/nonexistent/file.json"])
+        assert result.exit_code != 0
+
+    def test_diff_requires_id_in_file(self, runner):
+        """Diff needs an 'id' field to fetch the live state."""
+        data = {"name": "CPU Alert", "type": "metric alert", "query": "q"}
+
+        with runner.isolated_filesystem():
+            with open("monitor.json", "w") as f:
+                json.dump(data, f)
+            result = runner.invoke(diff_cmd, ["-f", "monitor.json"])
+
+        assert result.exit_code != 0
+        assert "id" in result.output.lower()
+
+    @patch("ddogctl.commands.apply.get_datadog_client")
+    def test_diff_monitor_shows_differences(self, mock_get_client, mock_client, runner):
+        mock_get_client.return_value = mock_client
+        live_monitor = Mock()
+        live_monitor.to_dict.return_value = {
+            "id": 12345,
+            "name": "CPU Alert",
+            "type": "metric alert",
+            "query": "avg:system.cpu{*} > 90",
+        }
+        mock_client.monitors.get_monitor.return_value = live_monitor
+
+        local_data = {
+            "id": 12345,
+            "name": "CPU Alert Updated",
+            "type": "metric alert",
+            "query": "avg:system.cpu{*} > 95",
+        }
+
+        with runner.isolated_filesystem():
+            with open("monitor.json", "w") as f:
+                json.dump(local_data, f)
+            result = runner.invoke(diff_cmd, ["-f", "monitor.json"])
+
+        assert result.exit_code == 0
+        # Should show differences between local and live
+        assert "CPU Alert Updated" in result.output or "---" in result.output
+
+    @patch("ddogctl.commands.apply.get_datadog_client")
+    def test_diff_monitor_no_differences(self, mock_get_client, mock_client, runner):
+        mock_get_client.return_value = mock_client
+        live_data = {
+            "id": 12345,
+            "name": "CPU Alert",
+            "type": "metric alert",
+            "query": "avg:system.cpu{*} > 90",
+        }
+        live_monitor = Mock()
+        live_monitor.to_dict.return_value = live_data
+        mock_client.monitors.get_monitor.return_value = live_monitor
+
+        with runner.isolated_filesystem():
+            with open("monitor.json", "w") as f:
+                json.dump(live_data, f)
+            result = runner.invoke(diff_cmd, ["-f", "monitor.json"])
+
+        assert result.exit_code == 0
+        assert "no differences" in result.output.lower() or "identical" in result.output.lower()
+
+    @patch("ddogctl.commands.apply.get_datadog_client")
+    def test_diff_dashboard(self, mock_get_client, mock_client, runner):
+        mock_get_client.return_value = mock_client
+        live_dash = Mock()
+        live_dash.to_dict.return_value = {
+            "id": "abc-123",
+            "title": "Old Title",
+            "layout_type": "ordered",
+            "widgets": [],
+        }
+        mock_client.dashboards.get_dashboard.return_value = live_dash
+
+        local_data = {
+            "id": "abc-123",
+            "title": "New Title",
+            "layout_type": "ordered",
+            "widgets": [],
+        }
+
+        with runner.isolated_filesystem():
+            with open("dash.json", "w") as f:
+                json.dump(local_data, f)
+            result = runner.invoke(diff_cmd, ["-f", "dash.json"])
+
+        assert result.exit_code == 0
+        mock_client.dashboards.get_dashboard.assert_called_once_with("abc-123")
+
+    @patch("ddogctl.commands.apply.get_datadog_client")
+    def test_diff_slo(self, mock_get_client, mock_client, runner):
+        mock_get_client.return_value = mock_client
+        live_slo = Mock()
+        live_slo.to_dict.return_value = {
+            "id": "slo-abc",
+            "name": "API SLO",
+            "type": "metric",
+            "thresholds": [{"timeframe": "30d", "target": 99.9}],
+        }
+        slo_response = Mock()
+        slo_response.data = live_slo
+        mock_client.slos.get_slo.return_value = slo_response
+
+        local_data = {
+            "id": "slo-abc",
+            "name": "API SLO Updated",
+            "type": "metric",
+            "thresholds": [{"timeframe": "30d", "target": 99.95}],
+        }
+
+        with runner.isolated_filesystem():
+            with open("slo.json", "w") as f:
+                json.dump(local_data, f)
+            result = runner.invoke(diff_cmd, ["-f", "slo.json"])
+
+        assert result.exit_code == 0
+        mock_client.slos.get_slo.assert_called_once_with("slo-abc")
+
+    @patch("ddogctl.commands.apply.get_datadog_client")
+    def test_diff_downtime(self, mock_get_client, mock_client, runner):
+        mock_get_client.return_value = mock_client
+        live_dt = Mock()
+        live_dt.to_dict.return_value = {
+            "id": 9876,
+            "scope": ["env:prod"],
+            "message": "Original",
+        }
+        mock_client.downtimes.get_downtime.return_value = live_dt
+
+        local_data = {
+            "id": 9876,
+            "scope": ["env:prod"],
+            "message": "Updated",
+        }
+
+        with runner.isolated_filesystem():
+            with open("downtime.json", "w") as f:
+                json.dump(local_data, f)
+            result = runner.invoke(diff_cmd, ["-f", "downtime.json"])
+
+        assert result.exit_code == 0
+        mock_client.downtimes.get_downtime.assert_called_once_with(9876)
+
+
+# ============================================================================
+# Integration with CLI
+# ============================================================================
+
+
+class TestApplyCliRegistration:
+    """Tests that apply and diff are registered as top-level commands."""
+
+    def test_apply_registered_on_main(self, runner):
+        from ddogctl.cli import main
+
+        result = runner.invoke(main, ["apply", "--help"])
+        assert result.exit_code == 0
+        assert "apply" in result.output.lower() or "--file" in result.output.lower()
+
+    def test_diff_registered_on_main(self, runner):
+        from ddogctl.cli import main
+
+        result = runner.invoke(main, ["diff", "--help"])
+        assert result.exit_code == 0
+        assert "diff" in result.output.lower() or "--file" in result.output.lower()


### PR DESCRIPTION
### **User description**
## Summary
- Add `apply` command with auto-detect, create-or-update, --dry-run, --recursive
- Add `diff` command comparing local file vs live state
- Resource type auto-detection from JSON structure (monitor, dashboard, SLO, downtime)
- Full TDD test coverage (39 new tests)

## Test plan
- [x] All 448 tests pass
- [x] Black formatting passes
- [x] Ruff linting passes


___

### **PR Type**
Enhancement


___

### **Description**
- Add `apply` command for declarative resource management with create-or-update logic

- Add `diff` command to compare local JSON files against live Datadog state

- Implement automatic resource type detection from JSON structure

- Support recursive directory scanning and dry-run mode for safe previews

- Include comprehensive test coverage with 39 new test cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Local JSON Files"] -->|detect_resource_type| B["Resource Type<br/>Monitor/Dashboard/SLO/Downtime"]
  B -->|apply_cmd| C["Create or Update<br/>via Datadog API"]
  B -->|diff_cmd| D["Fetch Live State"]
  D -->|compare| E["Show Unified Diff"]
  C -->|dry-run| F["Preview Changes"]
  A -->|recursive scan| G["Process Multiple Files"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.py</strong><dd><code>Register apply and diff commands in CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/cli.py

<ul><li>Import new <code>apply_cmd</code> and <code>diff_cmd</code> from <code>ddogctl.commands.apply</code> module<br> <li> Register both commands as top-level CLI commands via <br><code>main.add_command()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/19/files#diff-1ca1a58dd47b18afff9b729ec6430c335581acb24899da2e49951588191ea17e">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>apply.py</strong><dd><code>Add apply and diff command implementations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/commands/apply.py

<ul><li>Implement <code>detect_resource_type()</code> function with priority-based <br>detection (dashboard > SLO > downtime > monitor)<br> <li> Implement <code>_apply_single_resource()</code> for create-or-update logic with <br>dry-run support<br> <li> Implement <code>_fetch_live_state()</code> to retrieve current resource state from <br>Datadog API<br> <li> Implement <code>apply_cmd</code> Click command with file/directory input, recursive <br>scanning, and dry-run options<br> <li> Implement <code>diff_cmd</code> Click command to compare local JSON against live <br>state with unified diff output</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/19/files#diff-23f56f8e1082045ee3ab2e43426ab5c27013a8da6219a48968c10dfd2aca2b9e">+272/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_apply.py</strong><dd><code>Add comprehensive test suite for apply and diff</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/commands/test_apply.py

<ul><li>Add 10 tests for <code>detect_resource_type()</code> covering all resource types <br>and edge cases<br> <li> Add 20+ tests for <code>apply_cmd</code> including create/update for each resource <br>type, dry-run, and recursive directory scanning<br> <li> Add 10+ tests for <code>diff_cmd</code> covering file validation, live state <br>fetching, and diff output<br> <li> Add integration tests verifying command registration on main CLI<br> <li> Use mocking for Datadog API client and isolated filesystem for file <br>operations</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/19/files#diff-a2cd04cfaab8029382bde4a4e475859cafec4f51f01d06f7c0ced789f77d3a18">+613/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

