### PR TITLE
feat(errors): add structured JSON error output

### DIFF
--- a/ddogctl/utils/output.py
+++ b/ddogctl/utils/output.py
@@ -1,0 +1,43 @@
+"""Output format utilities."""
+
+import json
+import sys
+
+# Global output format state
+_output_format = "table"
+
+
+def set_output_format(fmt: str) -> None:
+    """Set the global output format."""
+    global _output_format
+    _output_format = fmt
+
+
+def get_output_format() -> str:
+    """Get the current output format."""
+    return _output_format
+
+
+def emit_error(code: str, status: int, message: str, hint: str = "") -> None:
+    """Emit an error in the appropriate format.
+
+    In JSON mode, outputs structured JSON to stderr.
+    In table mode, uses Rich console for pretty output.
+    """
+    if _output_format == "json":
+        error_obj = {
+            "error": True,
+            "code": code,
+            "status": status,
+            "message": message,
+        }
+        if hint:
+            error_obj["hint"] = hint
+        print(json.dumps(error_obj), file=sys.stderr)
+    else:
+        from rich.console import Console
+
+        console = Console(stderr=True)
+        console.print(f"[red]{message}[/red]")
+        if hint:
+            console.print(f"[dim]{hint}[/dim]")

--- a/tests/utils/test_output.py
+++ b/tests/utils/test_output.py
@@ -1,0 +1,133 @@
+"""Tests for output format utilities."""
+
+import json
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+
+from ddogctl.utils.output import emit_error, get_output_format, set_output_format
+
+
+@pytest.fixture(autouse=True)
+def reset_output_format():
+    """Reset output format to table after each test."""
+    yield
+    set_output_format("table")
+
+
+class TestOutputFormat:
+    """Test suite for output format state management."""
+
+    def test_default_format_is_table(self):
+        """Test that the default output format is table."""
+        assert get_output_format() == "table"
+
+    def test_set_json_format(self):
+        """Test switching to JSON output format."""
+        set_output_format("json")
+        assert get_output_format() == "json"
+
+    def test_set_table_format(self):
+        """Test explicitly setting table output format."""
+        set_output_format("json")
+        set_output_format("table")
+        assert get_output_format() == "table"
+
+
+class TestEmitError:
+    """Test suite for emit_error function."""
+
+    def test_json_format_outputs_to_stderr(self):
+        """Test that JSON mode outputs structured error JSON to stderr."""
+        set_output_format("json")
+        with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+            emit_error("AUTH_FAILED", 401, "Auth failed", "Check keys")
+
+        output = mock_stderr.getvalue()
+        data = json.loads(output)
+        assert data["error"] is True
+        assert data["code"] == "AUTH_FAILED"
+        assert data["status"] == 401
+        assert data["message"] == "Auth failed"
+        assert data["hint"] == "Check keys"
+
+    def test_json_format_without_hint(self):
+        """Test that JSON mode omits hint field when not provided."""
+        set_output_format("json")
+        with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+            emit_error("API_ERROR", 400, "Bad request")
+
+        output = mock_stderr.getvalue()
+        data = json.loads(output)
+        assert data["error"] is True
+        assert data["code"] == "API_ERROR"
+        assert data["status"] == 400
+        assert data["message"] == "Bad request"
+        assert "hint" not in data
+
+    def test_json_format_with_zero_status(self):
+        """Test JSON output with zero status for non-API errors."""
+        set_output_format("json")
+        with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+            emit_error("UNEXPECTED_ERROR", 0, "Something broke")
+
+        output = mock_stderr.getvalue()
+        data = json.loads(output)
+        assert data["status"] == 0
+        assert data["code"] == "UNEXPECTED_ERROR"
+
+    def test_json_format_all_error_codes(self):
+        """Test that all defined error codes produce valid JSON output."""
+        set_output_format("json")
+        error_codes = [
+            ("AUTH_FAILED", 401),
+            ("PERMISSION_DENIED", 403),
+            ("NOT_FOUND", 404),
+            ("RATE_LIMITED", 429),
+            ("SERVER_ERROR", 500),
+            ("API_ERROR", 400),
+            ("UNEXPECTED_ERROR", 0),
+        ]
+        for code, status in error_codes:
+            with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+                emit_error(code, status, f"Test {code}")
+            data = json.loads(mock_stderr.getvalue())
+            assert data["code"] == code
+            assert data["status"] == status
+
+    def test_table_format_uses_rich(self):
+        """Test that table mode outputs via Rich console without error."""
+        set_output_format("table")
+        with patch("rich.console.Console") as mock_console_cls:
+            mock_console = mock_console_cls.return_value
+            emit_error("AUTH_FAILED", 401, "Auth failed", "Check keys")
+
+        mock_console_cls.assert_called_once_with(stderr=True)
+        assert mock_console.print.call_count == 2
+        # First call: error message
+        error_call = mock_console.print.call_args_list[0][0][0]
+        assert "Auth failed" in error_call
+        # Second call: hint
+        hint_call = mock_console.print.call_args_list[1][0][0]
+        assert "Check keys" in hint_call
+
+    def test_table_format_without_hint(self):
+        """Test that table mode skips hint line when not provided."""
+        set_output_format("table")
+        with patch("rich.console.Console") as mock_console_cls:
+            mock_console = mock_console_cls.return_value
+            emit_error("API_ERROR", 400, "Bad request")
+
+        mock_console.print.assert_called_once()
+        call_arg = mock_console.print.call_args[0][0]
+        assert "Bad request" in call_arg
+
+    def test_json_output_is_single_line(self):
+        """Test that JSON output is a single line (no pretty printing)."""
+        set_output_format("json")
+        with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+            emit_error("AUTH_FAILED", 401, "Auth failed", "Check keys")
+
+        output = mock_stderr.getvalue().strip()
+        assert "\n" not in output


### PR DESCRIPTION
### **User description**
## Summary
- Adds dual-mode error output: structured JSON to stderr in JSON mode, Rich display in table mode
- New `ddogctl/utils/output.py` module with `emit_error`, `set_output_format`, and `get_output_format` utilities
- Error codes for all API error categories: `AUTH_FAILED`, `PERMISSION_DENIED`, `NOT_FOUND`, `RATE_LIMITED`, `SERVER_ERROR`, `API_ERROR`, `UNEXPECTED_ERROR`
- Enables AI agents and automation to parse error responses programmatically (Phase 3.1 of roadmap)

## Test plan
- [x] Verify JSON errors go to stderr with correct schema (test_output.py + test_error.py JSON mode tests)
- [x] Verify table errors preserve existing Rich format (test_output.py table tests)
- [x] Run full test suite (541 tests passing)
- [x] Formatting (black) and linting (ruff) pass


___

### **PR Type**
Enhancement


___

### **Description**
- Add structured JSON error output for agentic workflows

- Implement dual-mode error formatting: JSON to stderr, Rich table display

- Define error codes for all API error categories

- Refactor error handling to use centralized emit_error utility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Error Handling<br/>handle_api_error"] -->|calls| B["emit_error<br/>output.py"]
  B -->|JSON mode| C["stderr<br/>Structured JSON"]
  B -->|Table mode| D["Rich Console<br/>Pretty Display"]
  E["Error Codes<br/>AUTH_FAILED<br/>PERMISSION_DENIED<br/>NOT_FOUND<br/>RATE_LIMITED<br/>SERVER_ERROR<br/>API_ERROR<br/>UNEXPECTED_ERROR"] -->|used by| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>output.py</strong><dd><code>Add output format utilities with dual-mode error emission</code></dd></summary>
<hr>

ddogctl/utils/output.py

<ul><li>New module with <code>set_output_format()</code> and <code>get_output_format()</code> for <br>managing output mode<br> <li> Implement <code>emit_error()</code> function supporting dual-mode output: JSON to <br>stderr in JSON mode, Rich console in table mode<br> <li> JSON output includes error code, status, message, and optional hint <br>field</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/22/files#diff-08209c4a946ec9d3ba96837b57b87d2b3fb892d5021e48784230b9edaccb3252">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>error.py</strong><dd><code>Refactor error handling to use structured emit_error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/utils/error.py

<ul><li>Import and integrate <code>emit_error()</code> from output module<br> <li> Replace direct <code>console.print()</code> calls with <code>emit_error()</code> for all error <br>cases<br> <li> Add support for 404 NOT_FOUND error code with dedicated error handling<br> <li> Define error codes: AUTH_FAILED, PERMISSION_DENIED, NOT_FOUND, <br>RATE_LIMITED, SERVER_ERROR, API_ERROR, UNEXPECTED_ERROR<br> <li> Preserve retry logic and exponential backoff for 429 and 5xx errors</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/22/files#diff-2625d509d051ec1bb0f10a4cbaf48abe6034d59eec83a0229ac04351fe147727">+37/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_error.py</strong><dd><code>Update error tests for structured error output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/utils/test_error.py

<ul><li>Add fixture to reset output format to table after each test<br> <li> Replace <code>mock_console</code> assertions with <code>mock_emit_error</code> for error <br>validation<br> <li> Add new test class <code>TestHandleApiErrorJsonMode</code> with 5 tests validating <br>JSON output to stderr<br> <li> Add test for 404 NOT_FOUND error handling<br> <li> Update all existing tests to verify <code>emit_error()</code> calls with correct <br>error codes and parameters<br> <li> Verify retry messages still use <code>console.print()</code> while final errors use <br><code>emit_error()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/22/files#diff-02b91792b57168f0b6e38b0f0db01f502dea3655e5e998c8a72a374504b78811">+225/-70</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_output.py</strong><dd><code>Add comprehensive tests for output utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/utils/test_output.py

<ul><li>New test file with 2 test classes: <code>TestOutputFormat</code> and <code>TestEmitError</code><br> <li> Test output format state management (default table, switching to JSON)<br> <li> Test JSON mode outputs valid structured JSON to stderr with all <br>required fields<br> <li> Test table mode uses Rich console with stderr output<br> <li> Test all 7 error codes produce valid JSON output<br> <li> Test optional hint field is omitted when not provided</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/22/files#diff-ca2b03845dd86f3246185849d10073844154b7a0430ad72c10ae684972a8fe52">+133/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

