### PR TITLE
feat(errors): add semantic exit codes

### DIFF
--- a/ddogctl/utils/exit_codes.py
+++ b/ddogctl/utils/exit_codes.py
@@ -1,0 +1,45 @@
+"""Semantic exit codes for machine-readable CLI results."""
+
+# Success
+SUCCESS = 0
+
+# General/unexpected error
+GENERAL_ERROR = 1
+
+# Authentication or authorization failure (401, 403)
+AUTH_ERROR = 2
+
+# Resource not found (404)
+NOT_FOUND = 3
+
+# Validation error (400, invalid input)
+VALIDATION_ERROR = 4
+
+# Rate limited after all retries exhausted (429)
+RATE_LIMITED = 5
+
+# Server error after all retries exhausted (5xx)
+SERVER_ERROR = 6
+
+
+def exit_code_for_status(status: int) -> int:
+    """Map HTTP status code to semantic exit code.
+
+    Args:
+        status: HTTP status code from API response
+
+    Returns:
+        Semantic exit code
+    """
+    if status in (401, 403):
+        return AUTH_ERROR
+    elif status == 404:
+        return NOT_FOUND
+    elif status in (400, 422):
+        return VALIDATION_ERROR
+    elif status == 429:
+        return RATE_LIMITED
+    elif status >= 500:
+        return SERVER_ERROR
+    else:
+        return GENERAL_ERROR

--- a/tests/utils/test_exit_codes.py
+++ b/tests/utils/test_exit_codes.py
@@ -1,0 +1,67 @@
+"""Tests for semantic exit codes."""
+
+from ddogctl.utils.exit_codes import (
+    SUCCESS,
+    GENERAL_ERROR,
+    AUTH_ERROR,
+    NOT_FOUND,
+    VALIDATION_ERROR,
+    RATE_LIMITED,
+    SERVER_ERROR,
+    exit_code_for_status,
+)
+
+
+class TestExitCodeConstants:
+    def test_success_is_zero(self):
+        assert SUCCESS == 0
+
+    def test_general_error_is_one(self):
+        assert GENERAL_ERROR == 1
+
+    def test_auth_error_is_two(self):
+        assert AUTH_ERROR == 2
+
+    def test_not_found_is_three(self):
+        assert NOT_FOUND == 3
+
+    def test_validation_error_is_four(self):
+        assert VALIDATION_ERROR == 4
+
+    def test_rate_limited_is_five(self):
+        assert RATE_LIMITED == 5
+
+    def test_server_error_is_six(self):
+        assert SERVER_ERROR == 6
+
+
+class TestExitCodeForStatus:
+    def test_401_returns_auth_error(self):
+        assert exit_code_for_status(401) == AUTH_ERROR
+
+    def test_403_returns_auth_error(self):
+        assert exit_code_for_status(403) == AUTH_ERROR
+
+    def test_404_returns_not_found(self):
+        assert exit_code_for_status(404) == NOT_FOUND
+
+    def test_400_returns_validation_error(self):
+        assert exit_code_for_status(400) == VALIDATION_ERROR
+
+    def test_422_returns_validation_error(self):
+        assert exit_code_for_status(422) == VALIDATION_ERROR
+
+    def test_429_returns_rate_limited(self):
+        assert exit_code_for_status(429) == RATE_LIMITED
+
+    def test_500_returns_server_error(self):
+        assert exit_code_for_status(500) == SERVER_ERROR
+
+    def test_502_returns_server_error(self):
+        assert exit_code_for_status(502) == SERVER_ERROR
+
+    def test_503_returns_server_error(self):
+        assert exit_code_for_status(503) == SERVER_ERROR
+
+    def test_unknown_status_returns_general_error(self):
+        assert exit_code_for_status(418) == GENERAL_ERROR


### PR DESCRIPTION
### **User description**
## Summary
- Defines semantic exit codes (0-6) for machine-readable CLI results
- Maps HTTP status codes to meaningful exit codes (auth=2, not found=3, rate limited=5, etc.)
- Enables AI agents and scripts to programmatically handle different error types

## Test plan
- [ ] Verify each exit code constant has correct value
- [ ] Verify status code mapping covers all categories
- [ ] Run full test suite


___

### **PR Type**
Enhancement


___

### **Description**
- Introduces semantic exit codes (0-6) for machine-readable CLI results

- Maps HTTP status codes to meaningful exit codes for error categorization

- Updates error handler to use specific exit codes for auth, validation, not found, rate limit, and server errors

- Adds comprehensive test coverage for exit codes and error handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HTTP Status Codes"] -->|"401/403"| B["AUTH_ERROR = 2"]
  A -->|"404"| C["NOT_FOUND = 3"]
  A -->|"400/422"| D["VALIDATION_ERROR = 4"]
  A -->|"429"| E["RATE_LIMITED = 5"]
  A -->|"5xx"| F["SERVER_ERROR = 6"]
  A -->|"other"| G["GENERAL_ERROR = 1"]
  B --> H["Error Handler"]
  C --> H
  D --> H
  E --> H
  F --> H
  G --> H
  H -->|"sys.exit"| I["Machine-readable Exit Code"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>exit_codes.py</strong><dd><code>New semantic exit codes module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/utils/exit_codes.py

<ul><li>Defines seven semantic exit code constants (SUCCESS=0 through <br>SERVER_ERROR=6)<br> <li> Implements <code>exit_code_for_status()</code> function to map HTTP status codes to <br>exit codes<br> <li> Covers all major HTTP error categories with specific exit codes</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/23/files#diff-49ccc9f791210517590b88c82314dec0d076434c8d08489d2eb78da4c83cb31b">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>error.py</strong><dd><code>Update error handler with semantic exit codes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/utils/error.py

<ul><li>Imports semantic exit code constants and mapping function<br> <li> Replaces hardcoded <code>sys.exit(1)</code> calls with specific exit codes <br>(AUTH_ERROR, NOT_FOUND, RATE_LIMITED, SERVER_ERROR, GENERAL_ERROR)<br> <li> Adds explicit handling for 404 (NOT_FOUND) and 400/422 <br>(VALIDATION_ERROR) status codes<br> <li> Uses <code>exit_code_for_status()</code> for unmapped HTTP status codes</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/23/files#diff-2625d509d051ec1bb0f10a4cbaf48abe6034d59eec83a0229ac04351fe147727">+21/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_error.py</strong><dd><code>Update error handler tests for exit codes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/utils/test_error.py

<ul><li>Imports all semantic exit code constants for test assertions<br> <li> Updates all test assertions to verify specific exit codes instead of <br>generic code 1<br> <li> Adds validation error test for 400 status code with proper error <br>message verification<br> <li> Updates 404 test to verify NOT_FOUND exit code and "Resource not <br>found" message<br> <li> Improves test documentation with more descriptive docstrings</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/23/files#diff-02b91792b57168f0b6e38b0f0db01f502dea3655e5e998c8a72a374504b78811">+23/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_exit_codes.py</strong><dd><code>New exit codes test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/utils/test_exit_codes.py

<ul><li>Creates comprehensive test suite for exit code constants (7 tests)<br> <li> Tests <code>exit_code_for_status()</code> function with all mapped HTTP status <br>codes<br> <li> Covers edge cases including 401, 403, 404, 400, 422, 429, 5xx series, <br>and unknown codes<br> <li> Verifies correct mapping of each HTTP status to its semantic exit code</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/23/files#diff-12ad4ff5b33522067b47f337178274b0c2de278f412e39fc2ddaee6f5ceee48d">+67/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

