### PR TITLE
feat(stdin): add composable piping with --from-stdin

### DIFF
--- a/ddogctl/commands/dashboard.py
+++ b/ddogctl/commands/dashboard.py
@@ -9,6 +9,7 @@ from ddogctl.utils.error import handle_api_error
 from ddogctl.utils.file_input import load_json_option
 from ddogctl.utils.confirm import confirm_action
 from ddogctl.utils.export import export_to_json
+from ddogctl.utils.stdin import read_stdin_json, stdin_option
 
 console = Console()
 
@@ -124,6 +125,7 @@ def get_dashboard(dashboard_id, format):
     default=None,
     help="JSON file with dashboard definition",
 )
+@stdin_option
 @click.option(
     "--format",
     "fmt",
@@ -132,15 +134,21 @@ def get_dashboard(dashboard_id, format):
     help="Output format",
 )
 @handle_api_error
-def create_dashboard_cmd(title, layout_type, description, file_data, fmt):
-    """Create a dashboard from a JSON file or inline flags.
+def create_dashboard_cmd(title, layout_type, description, file_data, from_stdin, fmt):
+    """Create a dashboard from a JSON file, inline flags, or stdin.
 
     From file (primary workflow):
         ddogctl dashboard create -f dashboard.json
 
+    From stdin (piping):
+        ddogctl dashboard export abc-123 | ddogctl dashboard create --from-stdin --title "Copy"
+
     With inline flags (metadata only, no widgets):
         ddogctl dashboard create --title "My Dashboard" --layout-type ordered
     """
+    if from_stdin:
+        file_data = read_stdin_json()
+
     if file_data:
         body = file_data
     else:

--- a/ddogctl/commands/slo.py
+++ b/ddogctl/commands/slo.py
@@ -9,6 +9,7 @@ from ddogctl.utils.error import handle_api_error
 from ddogctl.utils.file_input import load_json_option
 from ddogctl.utils.confirm import confirm_action
 from ddogctl.utils.export import export_to_json
+from ddogctl.utils.stdin import read_stdin_json, stdin_option
 from ddogctl.utils.time import parse_time_range
 
 console = Console()
@@ -168,6 +169,7 @@ def get_slo(slo_id, fmt):
     default=None,
     help="JSON file with SLO definition",
 )
+@stdin_option
 @click.option(
     "--format",
     "fmt",
@@ -186,9 +188,19 @@ def create_slo(
     tags,
     description,
     file_data,
+    from_stdin,
     fmt,
 ):
-    """Create an SLO from inline flags or a JSON file."""
+    """Create an SLO from inline flags, a JSON file, or stdin.
+
+    Examples:
+        ddogctl slo create --type metric --name "API SLO" --thresholds "30d:99.9" ...
+        ddogctl slo create -f slo.json
+        ddogctl slo export abc123 | ddogctl slo create --from-stdin
+    """
+    if from_stdin:
+        file_data = read_stdin_json()
+
     if file_data:
         body = file_data
     else:

--- a/ddogctl/utils/stdin.py
+++ b/ddogctl/utils/stdin.py
@@ -1,0 +1,39 @@
+"""Stdin input utilities for composable piping."""
+
+import json
+import sys
+
+import click
+
+
+def read_stdin_json():
+    """Read JSON from stdin.
+
+    Returns:
+        Parsed JSON data (dict or list of dicts).
+
+    Raises:
+        click.ClickException: If stdin is empty or not valid JSON.
+    """
+    if sys.stdin.isatty():
+        raise click.ClickException("No input on stdin. Pipe JSON data or use -f <file>.")
+
+    data = sys.stdin.read().strip()
+    if not data:
+        raise click.ClickException("Empty stdin input.")
+
+    try:
+        return json.loads(data)
+    except json.JSONDecodeError as e:
+        raise click.ClickException(f"Invalid JSON on stdin: {e}")
+
+
+def stdin_option(func):
+    """Decorator that adds --from-stdin option to a Click command."""
+    return click.option(
+        "--from-stdin",
+        "from_stdin",
+        is_flag=True,
+        default=False,
+        help="Read JSON input from stdin (for piping).",
+    )(func)

--- a/tests/commands/test_stdin_integration.py
+++ b/tests/commands/test_stdin_integration.py
@@ -1,0 +1,479 @@
+"""Tests for stdin piping integration with commands."""
+
+import json
+
+import pytest
+from unittest.mock import Mock, patch
+from click.testing import CliRunner
+from ddogctl.commands.monitor import monitor
+from ddogctl.commands.dashboard import dashboard
+from ddogctl.commands.apply import apply_cmd
+from ddogctl.commands.slo import slo
+
+
+@pytest.fixture
+def mock_client():
+    """Create a mock Datadog client."""
+    client = Mock()
+    client.monitors = Mock()
+    client.dashboards = Mock()
+    client.slos = Mock()
+    client.downtimes = Mock()
+    return client
+
+
+@pytest.fixture
+def runner():
+    """Click CLI test runner."""
+    return CliRunner()
+
+
+# ============================================================================
+# Monitor Create --from-stdin Tests
+# ============================================================================
+
+
+class TestMonitorCreateFromStdin:
+    """Tests for monitor create with --from-stdin."""
+
+    def test_create_from_stdin(self, runner, mock_client):
+        """Test creating a monitor from piped JSON stdin."""
+        monitor_data = {
+            "name": "Test Monitor",
+            "type": "metric alert",
+            "query": "avg(last_5m):avg:system.cpu.user{*} > 90",
+            "message": "CPU is high",
+        }
+
+        created = Mock()
+        created.id = 12345
+        created.name = "Test Monitor"
+        created.to_dict.return_value = {"id": 12345, "name": "Test Monitor"}
+        mock_client.monitors.create_monitor.return_value = created
+
+        with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                monitor,
+                ["create", "--from-stdin"],
+                input=json.dumps(monitor_data),
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Monitor 12345 created" in result.output
+        mock_client.monitors.create_monitor.assert_called_once()
+
+    def test_create_from_stdin_json_output(self, runner, mock_client):
+        """Test creating a monitor from stdin with JSON output format."""
+        monitor_data = {
+            "name": "Test Monitor",
+            "type": "metric alert",
+            "query": "avg:system.cpu.user{*} > 90",
+        }
+
+        created = Mock()
+        created.id = 12345
+        created.name = "Test Monitor"
+        created.to_dict.return_value = {"id": 12345, "name": "Test Monitor"}
+        mock_client.monitors.create_monitor.return_value = created
+
+        with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                monitor,
+                ["create", "--from-stdin", "--format", "json"],
+                input=json.dumps(monitor_data),
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["id"] == 12345
+
+    def test_create_from_stdin_invalid_json(self, runner, mock_client):
+        """Test that invalid JSON on stdin produces an error."""
+        with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                monitor,
+                ["create", "--from-stdin"],
+                input="not valid json",
+            )
+
+        assert result.exit_code != 0
+
+    def test_create_from_stdin_overrides_file_flag(self, runner, mock_client, tmp_path):
+        """Test that --from-stdin takes precedence over -f."""
+        stdin_data = {
+            "name": "From Stdin",
+            "type": "metric alert",
+            "query": "avg:system.cpu.user{*} > 90",
+        }
+
+        created = Mock()
+        created.id = 999
+        created.name = "From Stdin"
+        created.to_dict.return_value = {"id": 999, "name": "From Stdin"}
+        mock_client.monitors.create_monitor.return_value = created
+
+        with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                monitor,
+                ["create", "--from-stdin"],
+                input=json.dumps(stdin_data),
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Monitor 999 created" in result.output
+
+
+# ============================================================================
+# Monitor Update --from-stdin Tests
+# ============================================================================
+
+
+class TestMonitorUpdateFromStdin:
+    """Tests for monitor update with --from-stdin."""
+
+    def test_update_from_stdin(self, runner, mock_client):
+        """Test updating a monitor from piped JSON stdin."""
+        update_data = {
+            "name": "Updated Monitor",
+            "query": "avg:system.cpu.user{*} > 95",
+        }
+
+        updated = Mock()
+        updated.id = 12345
+        updated.name = "Updated Monitor"
+        updated.to_dict.return_value = {"id": 12345, "name": "Updated Monitor"}
+        mock_client.monitors.update_monitor.return_value = updated
+
+        with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                monitor,
+                ["update", "12345", "--from-stdin"],
+                input=json.dumps(update_data),
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Monitor 12345 updated" in result.output
+        mock_client.monitors.update_monitor.assert_called_once()
+
+    def test_update_from_stdin_json_output(self, runner, mock_client):
+        """Test updating from stdin with JSON output format."""
+        update_data = {"name": "Updated Monitor"}
+
+        updated = Mock()
+        updated.id = 12345
+        updated.name = "Updated Monitor"
+        updated.to_dict.return_value = {"id": 12345, "name": "Updated Monitor"}
+        mock_client.monitors.update_monitor.return_value = updated
+
+        with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                monitor,
+                ["update", "12345", "--from-stdin", "--format", "json"],
+                input=json.dumps(update_data),
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["id"] == 12345
+
+
+# ============================================================================
+# Monitor Mute --from-stdin Tests
+# ============================================================================
+
+
+class TestMonitorMuteFromStdin:
+    """Tests for monitor mute with --from-stdin."""
+
+    def test_mute_from_stdin_list(self, runner, mock_client):
+        """Test muting multiple monitors from a piped list."""
+        monitors_data = [
+            {"id": 1, "name": "Alert Monitor 1"},
+            {"id": 2, "name": "Alert Monitor 2"},
+        ]
+
+        mock_client.monitors.update_monitor.return_value = Mock()
+
+        with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                monitor,
+                ["mute", "--from-stdin"],
+                input=json.dumps(monitors_data),
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Monitor 1 muted" in result.output
+        assert "Monitor 2 muted" in result.output
+        assert "2 monitor(s) muted" in result.output
+        assert mock_client.monitors.update_monitor.call_count == 2
+
+    def test_mute_from_stdin_single_object(self, runner, mock_client):
+        """Test muting a single monitor from stdin (single object, not array)."""
+        monitor_data = {"id": 42, "name": "Single Monitor"}
+
+        mock_client.monitors.update_monitor.return_value = Mock()
+
+        with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                monitor,
+                ["mute", "--from-stdin"],
+                input=json.dumps(monitor_data),
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Monitor 42 muted" in result.output
+        assert "1 monitor(s) muted" in result.output
+
+    def test_mute_from_stdin_with_duration(self, runner, mock_client):
+        """Test muting from stdin with --duration flag."""
+        monitors_data = [{"id": 1}]
+
+        mock_client.monitors.update_monitor.return_value = Mock()
+
+        with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                monitor,
+                ["mute", "--from-stdin", "--duration", "3600"],
+                input=json.dumps(monitors_data),
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Monitor 1 muted" in result.output
+        # Verify the update call included the end timestamp
+        call_kwargs = mock_client.monitors.update_monitor.call_args
+        body = call_kwargs[1]["body"] if "body" in call_kwargs[1] else call_kwargs[0][1]
+        assert hasattr(body, "end") and body.end is not None
+
+    def test_mute_from_stdin_skips_items_without_id(self, runner, mock_client):
+        """Test that items without 'id' field are skipped with a warning."""
+        monitors_data = [
+            {"id": 1, "name": "Valid"},
+            {"name": "No ID"},
+            {"id": 3, "name": "Also Valid"},
+        ]
+
+        mock_client.monitors.update_monitor.return_value = Mock()
+
+        with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                monitor,
+                ["mute", "--from-stdin"],
+                input=json.dumps(monitors_data),
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Skipping item without 'id' field" in result.output
+        assert "2 monitor(s) muted" in result.output
+
+    def test_mute_without_id_or_stdin_shows_error(self, runner, mock_client):
+        """Test that mute without monitor_id and without --from-stdin shows an error."""
+        with patch("ddogctl.commands.monitor.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(monitor, ["mute"])
+
+        assert result.exit_code != 0
+
+
+# ============================================================================
+# Dashboard Create --from-stdin Tests
+# ============================================================================
+
+
+class TestDashboardCreateFromStdin:
+    """Tests for dashboard create with --from-stdin."""
+
+    def test_create_from_stdin(self, runner, mock_client):
+        """Test creating a dashboard from piped JSON stdin."""
+        dash_data = {
+            "title": "My Dashboard",
+            "layout_type": "ordered",
+            "widgets": [{"type": "timeseries"}],
+        }
+
+        created = Mock()
+        created.id = "abc-def-123"
+        created.title = "My Dashboard"
+        created.to_dict.return_value = {"id": "abc-def-123", "title": "My Dashboard"}
+        mock_client.dashboards.create_dashboard.return_value = created
+
+        with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                dashboard,
+                ["create", "--from-stdin"],
+                input=json.dumps(dash_data),
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "abc-def-123" in result.output
+        mock_client.dashboards.create_dashboard.assert_called_once()
+
+    def test_create_from_stdin_with_title_override(self, runner, mock_client):
+        """Test that --title flag can override the title in stdin data.
+
+        Note: the title flag is separate from the file_data, so when --from-stdin
+        is used the file_data takes precedence (includes its own title).
+        """
+        dash_data = {
+            "title": "Original Title",
+            "layout_type": "ordered",
+            "widgets": [],
+        }
+
+        created = Mock()
+        created.id = "abc-def-456"
+        created.title = "Original Title"
+        created.to_dict.return_value = {"id": "abc-def-456", "title": "Original Title"}
+        mock_client.dashboards.create_dashboard.return_value = created
+
+        with patch("ddogctl.commands.dashboard.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                dashboard,
+                ["create", "--from-stdin"],
+                input=json.dumps(dash_data),
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        mock_client.dashboards.create_dashboard.assert_called_once()
+
+
+# ============================================================================
+# SLO Create --from-stdin Tests
+# ============================================================================
+
+
+class TestSloCreateFromStdin:
+    """Tests for SLO create with --from-stdin."""
+
+    def test_create_from_stdin(self, runner, mock_client):
+        """Test creating an SLO from piped JSON stdin."""
+        slo_data = {
+            "name": "API Availability",
+            "type": "metric",
+            "thresholds": [{"timeframe": "30d", "target": 99.9}],
+            "query": {
+                "numerator": "sum:requests.ok{*}",
+                "denominator": "sum:requests{*}",
+            },
+        }
+
+        created = Mock()
+        created.id = "slo-abc123"
+        created.name = "API Availability"
+        created.to_dict.return_value = {"id": "slo-abc123", "name": "API Availability"}
+        slo_response = Mock()
+        slo_response.data = [created]
+        mock_client.slos.create_slo.return_value = slo_response
+
+        with patch("ddogctl.commands.slo.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                slo,
+                ["create", "--from-stdin"],
+                input=json.dumps(slo_data),
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "slo-abc123" in result.output
+        mock_client.slos.create_slo.assert_called_once()
+
+
+# ============================================================================
+# Apply --from-stdin Tests
+# ============================================================================
+
+
+class TestApplyFromStdin:
+    """Tests for apply command with --from-stdin."""
+
+    @patch("ddogctl.commands.apply.get_datadog_client")
+    def test_apply_monitor_from_stdin(self, mock_get_client, runner, mock_client):
+        """Test applying a monitor from piped JSON stdin."""
+        mock_get_client.return_value = mock_client
+
+        created = Mock()
+        created.id = 12345
+        created.to_dict.return_value = {"id": 12345, "name": "CPU Alert"}
+        mock_client.monitors.create_monitor.return_value = created
+
+        monitor_data = {
+            "name": "CPU Alert",
+            "type": "metric alert",
+            "query": "avg:system.cpu{*} > 90",
+        }
+
+        result = runner.invoke(
+            apply_cmd,
+            ["--from-stdin"],
+            input=json.dumps(monitor_data),
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "12345" in result.output
+        mock_client.monitors.create_monitor.assert_called_once()
+
+    @patch("ddogctl.commands.apply.get_datadog_client")
+    def test_apply_dashboard_from_stdin(self, mock_get_client, runner, mock_client):
+        """Test applying a dashboard from piped JSON stdin."""
+        mock_get_client.return_value = mock_client
+
+        created = Mock()
+        created.id = "dash-abc"
+        created.to_dict.return_value = {"id": "dash-abc", "title": "Dashboard"}
+        mock_client.dashboards.create_dashboard.return_value = created
+
+        dash_data = {
+            "title": "Dashboard",
+            "layout_type": "ordered",
+            "widgets": [],
+        }
+
+        result = runner.invoke(
+            apply_cmd,
+            ["--from-stdin"],
+            input=json.dumps(dash_data),
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "dash-abc" in result.output
+        mock_client.dashboards.create_dashboard.assert_called_once()
+
+    def test_apply_from_stdin_dry_run(self, runner):
+        """Test that dry-run works with --from-stdin."""
+        monitor_data = {
+            "name": "CPU Alert",
+            "type": "metric alert",
+            "query": "avg:system.cpu{*} > 90",
+        }
+
+        result = runner.invoke(
+            apply_cmd,
+            ["--from-stdin", "--dry-run"],
+            input=json.dumps(monitor_data),
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "DRY RUN" in result.output
+
+    def test_apply_from_stdin_invalid_json(self, runner):
+        """Test that invalid JSON on stdin produces an error."""
+        result = runner.invoke(
+            apply_cmd,
+            ["--from-stdin"],
+            input="not valid json",
+        )
+
+        assert result.exit_code != 0
+
+    def test_apply_from_stdin_unrecognized_resource(self, runner):
+        """Test that unrecognized resource type from stdin produces an error."""
+        result = runner.invoke(
+            apply_cmd,
+            ["--from-stdin"],
+            input=json.dumps({"foo": "bar"}),
+        )
+
+        assert result.exit_code != 0
+
+    def test_apply_requires_file_or_stdin(self, runner):
+        """Test that apply fails without -f or --from-stdin."""
+        result = runner.invoke(apply_cmd, [])
+
+        assert result.exit_code != 0

--- a/tests/utils/test_stdin.py
+++ b/tests/utils/test_stdin.py
@@ -1,0 +1,78 @@
+"""Tests for stdin input utilities."""
+
+import json
+from io import StringIO
+from unittest.mock import patch
+
+import click
+import pytest
+
+from ddogctl.utils.stdin import read_stdin_json
+
+
+class TestReadStdinJson:
+    """Tests for the read_stdin_json function."""
+
+    def test_reads_valid_json_object(self):
+        """Test that a valid JSON object is parsed correctly."""
+        json_data = '{"name": "test", "type": "metric alert"}'
+        with patch("sys.stdin", new=StringIO(json_data)):
+            with patch("sys.stdin.isatty", return_value=False):
+                result = read_stdin_json()
+        assert result == {"name": "test", "type": "metric alert"}
+
+    def test_reads_valid_json_array(self):
+        """Test that a valid JSON array is parsed correctly."""
+        json_data = '[{"id": 1}, {"id": 2}]'
+        with patch("sys.stdin", new=StringIO(json_data)):
+            with patch("sys.stdin.isatty", return_value=False):
+                result = read_stdin_json()
+        assert result == [{"id": 1}, {"id": 2}]
+
+    def test_strips_whitespace(self):
+        """Test that leading/trailing whitespace is stripped."""
+        json_data = '  \n {"name": "test"} \n '
+        with patch("sys.stdin", new=StringIO(json_data)):
+            with patch("sys.stdin.isatty", return_value=False):
+                result = read_stdin_json()
+        assert result == {"name": "test"}
+
+    def test_raises_on_tty_stdin(self):
+        """Test that an error is raised when stdin is a TTY (no piped input)."""
+        with patch("sys.stdin.isatty", return_value=True):
+            with pytest.raises(click.ClickException, match="No input on stdin"):
+                read_stdin_json()
+
+    def test_raises_on_empty_stdin(self):
+        """Test that an error is raised when stdin is empty."""
+        with patch("sys.stdin", new=StringIO("")):
+            with patch("sys.stdin.isatty", return_value=False):
+                with pytest.raises(click.ClickException, match="Empty stdin"):
+                    read_stdin_json()
+
+    def test_raises_on_whitespace_only_stdin(self):
+        """Test that an error is raised when stdin contains only whitespace."""
+        with patch("sys.stdin", new=StringIO("   \n  ")):
+            with patch("sys.stdin.isatty", return_value=False):
+                with pytest.raises(click.ClickException, match="Empty stdin"):
+                    read_stdin_json()
+
+    def test_raises_on_invalid_json(self):
+        """Test that an error is raised for invalid JSON input."""
+        with patch("sys.stdin", new=StringIO("not json")):
+            with patch("sys.stdin.isatty", return_value=False):
+                with pytest.raises(click.ClickException, match="Invalid JSON"):
+                    read_stdin_json()
+
+    def test_reads_nested_json(self):
+        """Test that deeply nested JSON structures are parsed correctly."""
+        data = {
+            "name": "test",
+            "options": {"thresholds": {"critical": 90}},
+            "tags": ["env:prod", "service:web"],
+        }
+        json_data = json.dumps(data)
+        with patch("sys.stdin", new=StringIO(json_data)):
+            with patch("sys.stdin.isatty", return_value=False):
+                result = read_stdin_json()
+        assert result == data


### PR DESCRIPTION
### **User description**
## Summary
- Adds `ddogctl/utils/stdin.py` with `read_stdin_json()` and `stdin_option` decorator for reading JSON from stdin pipes
- Adds `--from-stdin` flag to monitor create/update/mute, dashboard create, SLO create, and apply commands
- Enables composable CLI workflows like `monitor list --format json | monitor mute --from-stdin`

## Test plan
- [x] Verify `read_stdin_json` parses valid JSON objects and arrays
- [x] Verify error on empty stdin, invalid JSON, whitespace-only stdin, and TTY stdin
- [x] Verify `monitor create --from-stdin` works with piped JSON
- [x] Verify `monitor update --from-stdin` works with piped JSON
- [x] Verify `monitor mute --from-stdin` handles lists, single objects, and items without ID
- [x] Verify `dashboard create --from-stdin` works with piped JSON
- [x] Verify `slo create --from-stdin` works with piped JSON
- [x] Verify `apply --from-stdin` works for monitors and dashboards, including dry-run
- [x] Run full test suite (553 tests passing)


___

### **PR Type**
Enhancement


___

### **Description**
- Add stdin piping support with `--from-stdin` flag to enable composable CLI workflows

- Implement `read_stdin_json()` utility and `stdin_option` decorator for JSON stdin parsing

- Enable piping patterns like `monitor list --format json | monitor mute --from-stdin`

- Add `--from-stdin` to monitor create/update/mute, dashboard create, SLO create, and apply commands


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["stdin.py<br/>read_stdin_json<br/>stdin_option"] --> B["monitor.py<br/>create/update/mute"]
  A --> C["dashboard.py<br/>create"]
  A --> D["slo.py<br/>create"]
  A --> E["apply.py<br/>apply"]
  B --> F["Composable<br/>Workflows"]
  C --> F
  D --> F
  E --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stdin.py</strong><dd><code>New stdin utility module for JSON piping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/utils/stdin.py

<ul><li>New utility module for reading JSON from stdin with <code>read_stdin_json()</code> <br>function<br> <li> Validates stdin is not a TTY, not empty, and contains valid JSON<br> <li> Provides <code>stdin_option</code> decorator to add <code>--from-stdin</code> flag to Click <br>commands<br> <li> Raises <code>click.ClickException</code> with descriptive errors for invalid input</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/24/files#diff-5054b6bdf8d500817458f3ffdff2a83cec522b6747a94f8f26051c7f6b7d132c">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>monitor.py</strong><dd><code>Add stdin piping to monitor commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/commands/monitor.py

<ul><li>Add <code>--from-stdin</code> option to <code>create_monitor_cmd</code> to read monitor JSON <br>from stdin<br> <li> Add <code>--from-stdin</code> option to <code>update_monitor_cmd</code> to read update JSON from <br>stdin<br> <li> Add <code>--from-stdin</code> option to <code>mute_monitor</code> with support for muting <br>multiple monitors from a list<br> <li> Make <code>monitor_id</code> argument optional in <code>mute_monitor</code> when using <br><code>--from-stdin</code><br> <li> Handle both single objects and arrays of monitors in mute stdin input<br> <li> Skip monitors without 'id' field with warning message</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/24/files#diff-cbca5eefc15920db1240a9f63066e274b6a7fb054f246dbff4ce5af1ebe842e8">+74/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dashboard.py</strong><dd><code>Add stdin piping to dashboard create</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/commands/dashboard.py

<ul><li>Add <code>--from-stdin</code> option to <code>create_dashboard_cmd</code> to read dashboard JSON <br>from stdin<br> <li> Update docstring with example of piping dashboard export to create<br> <li> Read stdin JSON data when <code>--from-stdin</code> flag is used</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/24/files#diff-3f82f2f688d03a855f6a60379cef8933e532fd38c9ef433a045de828eba02641">+10/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>slo.py</strong><dd><code>Add stdin piping to SLO create</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/commands/slo.py

<ul><li>Add <code>--from-stdin</code> option to <code>create_slo</code> command to read SLO JSON from <br>stdin<br> <li> Update docstring with example of piping SLO export to create<br> <li> Read stdin JSON data when <code>--from-stdin</code> flag is used</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/24/files#diff-783a86c141900a063bbe754862eaa5ffb74a7cdff09125c032013f97e54fe89a">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>apply.py</strong><dd><code>Add stdin piping to apply command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/commands/apply.py

<ul><li>Make <code>--file</code> option optional (was required) to support <code>--from-stdin</code> <br>alternative<br> <li> Add <code>--from-stdin</code> option to read resource JSON from stdin<br> <li> Add validation to require either <code>-f/--file</code> or <code>--from-stdin</code><br> <li> Handle stdin input by calling <code>_apply_single_resource()</code> with error <br>handling<br> <li> Update docstring with example of piping JSON to apply command</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/24/files#diff-23f56f8e1082045ee3ab2e43426ab5c27013a8da6219a48968c10dfd2aca2b9e">+19/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_stdin.py</strong><dd><code>Unit tests for stdin utility functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/utils/test_stdin.py

<ul><li>Test <code>read_stdin_json()</code> parsing of valid JSON objects and arrays<br> <li> Test whitespace stripping and nested JSON structure handling<br> <li> Test error cases: TTY stdin, empty stdin, whitespace-only stdin, <br>invalid JSON<br> <li> Comprehensive coverage of stdin utility function behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/24/files#diff-8b3736ed8963f238ee85c8bfbacc71abfa73f9bf7a5de0949a2e84822d47f294">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_stdin_integration.py</strong><dd><code>Integration tests for stdin piping commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/commands/test_stdin_integration.py

<ul><li>Integration tests for monitor create/update/mute with <code>--from-stdin</code><br> <li> Integration tests for dashboard create with <code>--from-stdin</code><br> <li> Integration tests for SLO create with <code>--from-stdin</code><br> <li> Integration tests for apply command with <code>--from-stdin</code> for monitors and <br>dashboards<br> <li> Test muting multiple monitors from list, single objects, with <br>duration, and skipping items without ID<br> <li> Test dry-run mode with stdin, invalid JSON handling, and validation of <br>required flags</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/24/files#diff-76ed0896da11111f8cc6459cdcea4e2b811d89869ab2e915ad74f89a18bc3d80">+479/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

