### PR TITLE
feat(usage): add usage metering commands

### DIFF
--- a/ddogctl/cli.py
+++ b/ddogctl/cli.py
@@ -84,6 +84,7 @@ from ddogctl.commands.apply import apply_cmd, diff_cmd
 from ddogctl.commands.config import config
 from ddogctl.commands.incident import incident
 from ddogctl.commands.user import user
+from ddogctl.commands.usage import usage
 
 main.add_command(monitor)
 main.add_command(metric)
@@ -104,6 +105,7 @@ main.add_command(diff_cmd)
 main.add_command(config)
 main.add_command(incident)
 main.add_command(user)
+main.add_command(usage)
 
 
 if __name__ == "__main__":

--- a/ddogctl/client.py
+++ b/ddogctl/client.py
@@ -12,6 +12,7 @@ from datadog_api_client.v1.api import (
     downtimes_api,
     service_level_objectives_api,
     dashboards_api,
+    usage_metering_api,
 )
 from datadog_api_client.v2.api import (
     logs_api,
@@ -48,6 +49,7 @@ class DatadogClient:
         self.downtimes = downtimes_api.DowntimesApi(self.api_client)
         self.slos = service_level_objectives_api.ServiceLevelObjectivesApi(self.api_client)
         self.dashboards = dashboards_api.DashboardsApi(self.api_client)
+        self.usage = usage_metering_api.UsageMeteringApi(self.api_client)
 
         # V2 APIs
         self.logs = logs_api.LogsApi(self.api_client)

--- a/ddogctl/commands/usage.py
+++ b/ddogctl/commands/usage.py
@@ -1,0 +1,337 @@
+"""Usage metering commands."""
+
+import click
+import json
+from datetime import datetime, date, timedelta
+from rich.console import Console
+from rich.table import Table
+from ddogctl.client import get_datadog_client
+from ddogctl.utils.error import handle_api_error
+
+console = Console()
+
+
+def _parse_date(value: str, default_days_ago: int = 7) -> date:
+    """Parse a date string or relative time like '7d' into a date object.
+
+    Args:
+        value: Date string in YYYY-MM-DD format, or relative like '7d', '30d'.
+        default_days_ago: Default number of days ago if value is None.
+
+    Returns:
+        A date object.
+    """
+    if value is None:
+        return date.today() - timedelta(days=default_days_ago)
+
+    if value == "now" or value == "today":
+        return date.today()
+
+    # Relative days format: "7d", "30d"
+    if value.endswith("d") and value[:-1].isdigit():
+        days = int(value[:-1])
+        return date.today() - timedelta(days=days)
+
+    # ISO date format: YYYY-MM-DD
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        raise click.BadParameter(f"Invalid date format: {value}. Use YYYY-MM-DD or Nd (e.g., 7d).")
+
+
+def _parse_datetime(value: str, default_hours_ago: int = 24) -> datetime:
+    """Parse a datetime string or relative time into a datetime object.
+
+    Args:
+        value: Datetime string or relative like '24h', '7d'.
+        default_hours_ago: Default number of hours ago if value is None.
+
+    Returns:
+        A datetime object.
+    """
+    if value is None:
+        return datetime.now() - timedelta(hours=default_hours_ago)
+
+    if value == "now":
+        return datetime.now()
+
+    # Relative hours: "1h", "24h"
+    if value.endswith("h") and value[:-1].isdigit():
+        hours = int(value[:-1])
+        return datetime.now() - timedelta(hours=hours)
+
+    # Relative days: "7d", "30d"
+    if value.endswith("d") and value[:-1].isdigit():
+        days = int(value[:-1])
+        return datetime.now() - timedelta(days=days)
+
+    # ISO datetime or date format
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        raise click.BadParameter(
+            f"Invalid datetime format: {value}. Use YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS, or Nh/Nd."
+        )
+
+
+@click.group()
+def usage():
+    """Usage metering and cost visibility commands."""
+    pass
+
+
+@usage.command(name="summary")
+@click.option(
+    "--from",
+    "from_date",
+    default="7d",
+    help="Start date (YYYY-MM-DD or Nd, e.g., 7d, 30d). Default: 7d.",
+)
+@click.option(
+    "--to",
+    "to_date",
+    default="today",
+    help="End date (YYYY-MM-DD or 'today'). Default: today.",
+)
+@click.option("--format", type=click.Choice(["json", "table"]), default="table")
+@handle_api_error
+def summary(from_date, to_date, format):
+    """Show usage summary across all product families."""
+    client = get_datadog_client()
+
+    start_d = _parse_date(from_date, default_days_ago=7)
+    end_d = _parse_date(to_date, default_days_ago=0)
+
+    with console.status("[cyan]Fetching usage summary...[/cyan]"):
+        response = client.usage.get_usage_summary(start_d=start_d, end_d=end_d)
+
+    if format == "json":
+        data = {
+            "start_date": str(getattr(response, "start_date", start_d)),
+            "end_date": str(getattr(response, "end_date", end_d)),
+            "apm_host_top99p": getattr(response, "apm_host_top99p", None),
+            "infra_host_top99p": getattr(response, "infra_host_top99p", None),
+            "container_avg": getattr(response, "container_avg", None),
+            "custom_ts_avg": getattr(response, "custom_ts_avg", None),
+            "logs_indexed_logs_usage_agg_sum": getattr(
+                response, "logs_indexed_logs_usage_agg_sum", None
+            ),
+            "ingested_events_bytes_agg_sum": getattr(
+                response, "ingested_events_bytes_agg_sum", None
+            ),
+        }
+        print(json.dumps(data, indent=2, default=str))
+    else:
+        table = Table(title=f"Usage Summary ({start_d} to {end_d})")
+        table.add_column("Metric", style="cyan")
+        table.add_column("Value", justify="right", style="yellow")
+
+        fields = [
+            ("APM Hosts (top 99p)", "apm_host_top99p"),
+            ("Infra Hosts (top 99p)", "infra_host_top99p"),
+            ("Containers (avg)", "container_avg"),
+            ("Custom Metrics (avg)", "custom_ts_avg"),
+            ("Indexed Logs (sum)", "logs_indexed_logs_usage_agg_sum"),
+            ("Ingested Events Bytes (sum)", "ingested_events_bytes_agg_sum"),
+        ]
+
+        has_data = False
+        for label, attr in fields:
+            value = getattr(response, attr, None)
+            if value is not None:
+                has_data = True
+                table.add_row(
+                    label, f"{value:,}" if isinstance(value, (int, float)) else str(value)
+                )
+
+        if not has_data:
+            console.print("[dim]No usage data found for the specified period.[/dim]")
+        else:
+            console.print(table)
+
+
+@usage.command(name="hosts")
+@click.option(
+    "--from",
+    "from_time",
+    default="24h",
+    help="Start time (YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS, or Nh/Nd). Default: 24h.",
+)
+@click.option(
+    "--to",
+    "to_time",
+    default="now",
+    help="End time. Default: now.",
+)
+@click.option("--format", type=click.Choice(["json", "table"]), default="table")
+@handle_api_error
+def hosts_usage(from_time, to_time, format):
+    """Show host usage hour by hour."""
+    client = get_datadog_client()
+
+    start_hr = _parse_datetime(from_time, default_hours_ago=24)
+    end_hr = _parse_datetime(to_time, default_hours_ago=0)
+
+    with console.status("[cyan]Fetching host usage...[/cyan]"):
+        response = client.usage.get_usage_hosts(start_hr=start_hr, end_hr=end_hr)
+
+    usage_list = response.usage if hasattr(response, "usage") and response.usage else []
+
+    if format == "json":
+        output = []
+        for entry in usage_list:
+            output.append(
+                {
+                    "hour": str(getattr(entry, "hour", "")),
+                    "host_count": getattr(entry, "host_count", None),
+                    "container_count": getattr(entry, "container_count", None),
+                    "apm_host_count": getattr(entry, "apm_host_count", None),
+                }
+            )
+        print(json.dumps(output, indent=2, default=str))
+    else:
+        table = Table(title="Host Usage")
+        table.add_column("Hour", style="cyan")
+        table.add_column("Hosts", justify="right", style="yellow")
+        table.add_column("Containers", justify="right", style="white")
+        table.add_column("APM Hosts", justify="right", style="green")
+
+        for entry in usage_list:
+            hour = str(getattr(entry, "hour", ""))
+            host_count = getattr(entry, "host_count", None)
+            container_count = getattr(entry, "container_count", None)
+            apm_host_count = getattr(entry, "apm_host_count", None)
+
+            table.add_row(
+                hour,
+                str(host_count) if host_count is not None else "-",
+                str(container_count) if container_count is not None else "-",
+                str(apm_host_count) if apm_host_count is not None else "-",
+            )
+
+        console.print(table)
+        console.print(f"\n[dim]Total entries: {len(usage_list)}[/dim]")
+
+
+@usage.command(name="logs")
+@click.option(
+    "--from",
+    "from_time",
+    default="24h",
+    help="Start time (YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS, or Nh/Nd). Default: 24h.",
+)
+@click.option(
+    "--to",
+    "to_time",
+    default="now",
+    help="End time. Default: now.",
+)
+@click.option("--format", type=click.Choice(["json", "table"]), default="table")
+@handle_api_error
+def logs_usage(from_time, to_time, format):
+    """Show log usage hour by hour."""
+    client = get_datadog_client()
+
+    start_hr = _parse_datetime(from_time, default_hours_ago=24)
+    end_hr = _parse_datetime(to_time, default_hours_ago=0)
+
+    with console.status("[cyan]Fetching log usage...[/cyan]"):
+        response = client.usage.get_usage_logs(start_hr=start_hr, end_hr=end_hr)
+
+    usage_list = response.usage if hasattr(response, "usage") and response.usage else []
+
+    if format == "json":
+        output = []
+        for entry in usage_list:
+            output.append(
+                {
+                    "hour": str(getattr(entry, "hour", "")),
+                    "ingested_events_count": getattr(entry, "ingested_events_count", None),
+                    "indexed_events_count": getattr(entry, "indexed_events_count", None),
+                }
+            )
+        print(json.dumps(output, indent=2, default=str))
+    else:
+        table = Table(title="Log Usage")
+        table.add_column("Hour", style="cyan")
+        table.add_column("Ingested Events", justify="right", style="yellow")
+        table.add_column("Indexed Events", justify="right", style="white")
+
+        for entry in usage_list:
+            hour = str(getattr(entry, "hour", ""))
+            ingested = getattr(entry, "ingested_events_count", None)
+            indexed = getattr(entry, "indexed_events_count", None)
+
+            table.add_row(
+                hour,
+                str(ingested) if ingested is not None else "-",
+                str(indexed) if indexed is not None else "-",
+            )
+
+        console.print(table)
+        console.print(f"\n[dim]Total entries: {len(usage_list)}[/dim]")
+
+
+@usage.command(name="top-avg-metrics")
+@click.option(
+    "--month",
+    "month_str",
+    default=None,
+    help="Month in YYYY-MM format. Default: current month.",
+)
+@click.option("--format", type=click.Choice(["json", "table"]), default="table")
+@handle_api_error
+def top_avg_metrics(month_str, format):
+    """Show top custom metrics by average count."""
+    client = get_datadog_client()
+
+    if month_str:
+        try:
+            month_dt = datetime.strptime(month_str, "%Y-%m")
+        except ValueError:
+            raise click.BadParameter(
+                f"Invalid month format: {month_str}. Use YYYY-MM (e.g., 2024-01)."
+            )
+    else:
+        now = datetime.now()
+        month_dt = datetime(now.year, now.month, 1)
+
+    with console.status("[cyan]Fetching top average metrics...[/cyan]"):
+        response = client.usage.get_usage_top_avg_metrics(month=month_dt)
+
+    usage_list = response.usage if hasattr(response, "usage") and response.usage else []
+
+    if format == "json":
+        output = []
+        for entry in usage_list:
+            output.append(
+                {
+                    "metric_name": getattr(entry, "metric_name", None),
+                    "avg_metric_hour": getattr(entry, "avg_metric_hour", None),
+                    "max_metric_hour": getattr(entry, "max_metric_hour", None),
+                    "metric_category": getattr(entry, "metric_category", None),
+                }
+            )
+        print(json.dumps(output, indent=2, default=str))
+    else:
+        table = Table(title=f"Top Average Metrics ({month_dt.strftime('%Y-%m')})")
+        table.add_column("Metric Name", style="cyan", min_width=30)
+        table.add_column("Avg/Hour", justify="right", style="yellow")
+        table.add_column("Max/Hour", justify="right", style="white")
+        table.add_column("Category", style="dim")
+
+        for entry in usage_list:
+            name = getattr(entry, "metric_name", None) or ""
+            avg_hr = getattr(entry, "avg_metric_hour", None)
+            max_hr = getattr(entry, "max_metric_hour", None)
+            category = getattr(entry, "metric_category", None) or ""
+
+            table.add_row(
+                name,
+                str(avg_hr) if avg_hr is not None else "-",
+                str(max_hr) if max_hr is not None else "-",
+                category,
+            )
+
+        console.print(table)
+        console.print(f"\n[dim]Total metrics: {len(usage_list)}[/dim]")

--- a/tests/commands/test_usage.py
+++ b/tests/commands/test_usage.py
@@ -1,0 +1,329 @@
+"""Tests for usage metering commands."""
+
+import json
+from datetime import datetime
+from unittest.mock import Mock, patch
+
+
+def test_usage_summary_table(mock_client, runner):
+    """Test usage summary in table format."""
+    from ddogctl.commands.usage import usage
+
+    mock_response = Mock()
+    mock_response.start_date = "2024-01-01"
+    mock_response.end_date = "2024-01-07"
+    mock_response.apm_host_top99p = 15
+    mock_response.infra_host_top99p = 120
+    mock_response.container_avg = 350
+    mock_response.custom_ts_avg = 5000
+    mock_response.logs_indexed_logs_usage_agg_sum = 1200000
+    mock_response.ingested_events_bytes_agg_sum = 9500000
+
+    mock_client.usage.get_usage_summary.return_value = mock_response
+
+    with patch("ddogctl.commands.usage.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(usage, ["summary", "--from", "2024-01-01", "--to", "2024-01-07"])
+
+    assert result.exit_code == 0
+    assert "Usage Summary" in result.output
+    assert "APM Hosts" in result.output
+    assert "15" in result.output
+    assert "120" in result.output
+    assert "350" in result.output
+    assert "5,000" in result.output
+
+
+def test_usage_summary_json(mock_client, runner):
+    """Test usage summary in JSON format."""
+    from ddogctl.commands.usage import usage
+
+    mock_response = Mock()
+    mock_response.start_date = "2024-01-01"
+    mock_response.end_date = "2024-01-07"
+    mock_response.apm_host_top99p = 15
+    mock_response.infra_host_top99p = 120
+    mock_response.container_avg = 350
+    mock_response.custom_ts_avg = 5000
+    mock_response.logs_indexed_logs_usage_agg_sum = 1200000
+    mock_response.ingested_events_bytes_agg_sum = 9500000
+
+    mock_client.usage.get_usage_summary.return_value = mock_response
+
+    with patch("ddogctl.commands.usage.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            usage, ["summary", "--from", "2024-01-01", "--to", "2024-01-07", "--format", "json"]
+        )
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["apm_host_top99p"] == 15
+    assert data["infra_host_top99p"] == 120
+    assert data["container_avg"] == 350
+    assert data["custom_ts_avg"] == 5000
+    assert data["logs_indexed_logs_usage_agg_sum"] == 1200000
+    assert data["ingested_events_bytes_agg_sum"] == 9500000
+
+
+def test_usage_summary_empty(mock_client, runner):
+    """Test usage summary with no data."""
+    from ddogctl.commands.usage import usage
+
+    mock_response = Mock(spec=[])
+
+    mock_client.usage.get_usage_summary.return_value = mock_response
+
+    with patch("ddogctl.commands.usage.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(usage, ["summary", "--from", "2024-01-01", "--to", "2024-01-07"])
+
+    assert result.exit_code == 0
+    assert "No usage data found" in result.output
+
+
+def test_usage_hosts_table(mock_client, runner):
+    """Test host usage in table format."""
+    from ddogctl.commands.usage import usage
+
+    entry1 = Mock()
+    entry1.hour = datetime(2024, 1, 7, 10, 0, 0)
+    entry1.host_count = 120
+    entry1.container_count = 350
+    entry1.apm_host_count = 15
+
+    entry2 = Mock()
+    entry2.hour = datetime(2024, 1, 7, 11, 0, 0)
+    entry2.host_count = 122
+    entry2.container_count = 355
+    entry2.apm_host_count = 15
+
+    mock_response = Mock()
+    mock_response.usage = [entry1, entry2]
+
+    mock_client.usage.get_usage_hosts.return_value = mock_response
+
+    with patch("ddogctl.commands.usage.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(usage, ["hosts", "--from", "24h", "--to", "now"])
+
+    assert result.exit_code == 0
+    assert "Host Usage" in result.output
+    assert "120" in result.output
+    assert "122" in result.output
+    assert "350" in result.output
+    assert "Total entries: 2" in result.output
+
+
+def test_usage_hosts_json(mock_client, runner):
+    """Test host usage in JSON format."""
+    from ddogctl.commands.usage import usage
+
+    entry1 = Mock()
+    entry1.hour = datetime(2024, 1, 7, 10, 0, 0)
+    entry1.host_count = 120
+    entry1.container_count = 350
+    entry1.apm_host_count = 15
+
+    mock_response = Mock()
+    mock_response.usage = [entry1]
+
+    mock_client.usage.get_usage_hosts.return_value = mock_response
+
+    with patch("ddogctl.commands.usage.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(usage, ["hosts", "--from", "24h", "--format", "json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert len(data) == 1
+    assert data[0]["host_count"] == 120
+    assert data[0]["container_count"] == 350
+    assert data[0]["apm_host_count"] == 15
+
+
+def test_usage_logs_table(mock_client, runner):
+    """Test log usage in table format."""
+    from ddogctl.commands.usage import usage
+
+    entry1 = Mock()
+    entry1.hour = datetime(2024, 1, 7, 10, 0, 0)
+    entry1.ingested_events_count = 500000
+    entry1.indexed_events_count = 125000
+
+    entry2 = Mock()
+    entry2.hour = datetime(2024, 1, 7, 11, 0, 0)
+    entry2.ingested_events_count = 520000
+    entry2.indexed_events_count = 130000
+
+    mock_response = Mock()
+    mock_response.usage = [entry1, entry2]
+
+    mock_client.usage.get_usage_logs.return_value = mock_response
+
+    with patch("ddogctl.commands.usage.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(usage, ["logs", "--from", "24h", "--to", "now"])
+
+    assert result.exit_code == 0
+    assert "Log Usage" in result.output
+    assert "500000" in result.output
+    assert "125000" in result.output
+    assert "Total entries: 2" in result.output
+
+
+def test_usage_logs_json(mock_client, runner):
+    """Test log usage in JSON format."""
+    from ddogctl.commands.usage import usage
+
+    entry1 = Mock()
+    entry1.hour = datetime(2024, 1, 7, 10, 0, 0)
+    entry1.ingested_events_count = 500000
+    entry1.indexed_events_count = 125000
+
+    mock_response = Mock()
+    mock_response.usage = [entry1]
+
+    mock_client.usage.get_usage_logs.return_value = mock_response
+
+    with patch("ddogctl.commands.usage.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(usage, ["logs", "--from", "24h", "--format", "json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert len(data) == 1
+    assert data[0]["ingested_events_count"] == 500000
+    assert data[0]["indexed_events_count"] == 125000
+
+
+def test_usage_top_avg_metrics_table(mock_client, runner):
+    """Test top average metrics in table format."""
+    from ddogctl.commands.usage import usage
+
+    entry1 = Mock()
+    entry1.metric_name = "system.cpu.user"
+    entry1.avg_metric_hour = 42
+    entry1.max_metric_hour = 89
+    entry1.metric_category = "custom"
+
+    entry2 = Mock()
+    entry2.metric_name = "app.request.count"
+    entry2.avg_metric_hour = 120
+    entry2.max_metric_hour = 250
+    entry2.metric_category = "custom"
+
+    mock_response = Mock()
+    mock_response.usage = [entry1, entry2]
+
+    mock_client.usage.get_usage_top_avg_metrics.return_value = mock_response
+
+    with patch("ddogctl.commands.usage.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(usage, ["top-avg-metrics", "--month", "2024-01"])
+
+    assert result.exit_code == 0
+    assert "Top Average Metrics" in result.output
+    assert "2024-01" in result.output
+    assert "system.cpu.user" in result.output
+    assert "app.request.count" in result.output
+    assert "42" in result.output
+    assert "120" in result.output
+    assert "Total metrics: 2" in result.output
+
+
+def test_usage_top_avg_metrics_json(mock_client, runner):
+    """Test top average metrics in JSON format."""
+    from ddogctl.commands.usage import usage
+
+    entry1 = Mock()
+    entry1.metric_name = "system.cpu.user"
+    entry1.avg_metric_hour = 42
+    entry1.max_metric_hour = 89
+    entry1.metric_category = "custom"
+
+    mock_response = Mock()
+    mock_response.usage = [entry1]
+
+    mock_client.usage.get_usage_top_avg_metrics.return_value = mock_response
+
+    with patch("ddogctl.commands.usage.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(usage, ["top-avg-metrics", "--month", "2024-01", "--format", "json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert len(data) == 1
+    assert data[0]["metric_name"] == "system.cpu.user"
+    assert data[0]["avg_metric_hour"] == 42
+    assert data[0]["max_metric_hour"] == 89
+    assert data[0]["metric_category"] == "custom"
+
+
+def test_usage_hosts_empty(mock_client, runner):
+    """Test host usage with no data."""
+    from ddogctl.commands.usage import usage
+
+    mock_response = Mock()
+    mock_response.usage = []
+
+    mock_client.usage.get_usage_hosts.return_value = mock_response
+
+    with patch("ddogctl.commands.usage.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(usage, ["hosts", "--from", "24h"])
+
+    assert result.exit_code == 0
+    assert "Total entries: 0" in result.output
+
+
+def test_usage_logs_empty(mock_client, runner):
+    """Test log usage with no data."""
+    from ddogctl.commands.usage import usage
+
+    mock_response = Mock()
+    mock_response.usage = []
+
+    mock_client.usage.get_usage_logs.return_value = mock_response
+
+    with patch("ddogctl.commands.usage.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(usage, ["logs", "--from", "24h"])
+
+    assert result.exit_code == 0
+    assert "Total entries: 0" in result.output
+
+
+def test_usage_top_avg_metrics_default_month(mock_client, runner):
+    """Test top average metrics defaults to current month."""
+    from ddogctl.commands.usage import usage
+
+    mock_response = Mock()
+    mock_response.usage = []
+
+    mock_client.usage.get_usage_top_avg_metrics.return_value = mock_response
+
+    with patch("ddogctl.commands.usage.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(usage, ["top-avg-metrics"])
+
+    assert result.exit_code == 0
+    assert "Total metrics: 0" in result.output
+
+    # Verify the month parameter was set to the first of the current month
+    call_kwargs = mock_client.usage.get_usage_top_avg_metrics.call_args.kwargs
+    now = datetime.now()
+    assert call_kwargs["month"].year == now.year
+    assert call_kwargs["month"].month == now.month
+    assert call_kwargs["month"].day == 1
+
+
+def test_usage_summary_relative_dates(mock_client, runner):
+    """Test summary command with relative date format (e.g., 30d)."""
+    from ddogctl.commands.usage import usage
+
+    mock_response = Mock()
+    mock_response.apm_host_top99p = 10
+    mock_response.infra_host_top99p = 50
+    mock_response.container_avg = None
+    mock_response.custom_ts_avg = None
+    mock_response.logs_indexed_logs_usage_agg_sum = None
+    mock_response.ingested_events_bytes_agg_sum = None
+
+    mock_client.usage.get_usage_summary.return_value = mock_response
+
+    with patch("ddogctl.commands.usage.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(usage, ["summary", "--from", "30d"])
+
+    assert result.exit_code == 0
+    assert "Usage Summary" in result.output
+    assert "10" in result.output
+    assert "50" in result.output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ def mock_client():
     client.dashboards = Mock()
     client.incidents = Mock()
     client.users = Mock()
+    client.usage = Mock()
     return client
 
 


### PR DESCRIPTION
### **User description**
## Summary
- Add `ddogctl usage` command group with `summary`, `hosts`, `logs`, `top-avg-metrics` subcommands
- Support for usage metering via `UsageMeteringApi` (v1)
- Rich table and JSON output formats
- Flexible time parsing: relative (`7d`, `24h`) and absolute (`YYYY-MM-DD`) date formats

## Test plan
- [x] Unit tests for all subcommands (13 tests)
- [x] Time range parsing tested (relative and absolute)
- [x] Empty results handling
- [x] pytest (599 passed), black, ruff all pass


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `ddogctl usage` command group with four subcommands for usage metering

- Implement `summary`, `hosts`, `logs`, `top-avg-metrics` subcommands with flexible date/time parsing

- Support both table and JSON output formats for all usage commands

- Add comprehensive unit tests covering all subcommands and edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["CLI Entry Point"] -- "imports usage module" --> Usage["Usage Command Group"]
  Client["Datadog Client"] -- "adds UsageMeteringApi" --> API["UsageMeteringApi"]
  Usage -- "calls" --> API
  Usage -- "summary" --> Summary["Summary Subcommand"]
  Usage -- "hosts" --> Hosts["Hosts Subcommand"]
  Usage -- "logs" --> Logs["Logs Subcommand"]
  Usage -- "top-avg-metrics" --> Metrics["Top Avg Metrics Subcommand"]
  Summary -- "outputs" --> Output["Table/JSON Format"]
  Hosts -- "outputs" --> Output
  Logs -- "outputs" --> Output
  Metrics -- "outputs" --> Output
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.py</strong><dd><code>Register usage command with CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/cli.py

<ul><li>Import new <code>usage</code> command module<br> <li> Register <code>usage</code> command group with main CLI</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/27/files#diff-1ca1a58dd47b18afff9b729ec6430c335581acb24899da2e49951588191ea17e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Add UsageMeteringApi to client wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/client.py

<ul><li>Import <code>UsageMeteringApi</code> from datadog_api_client.v1.api<br> <li> Initialize <code>self.usage</code> attribute with UsageMeteringApi instance</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/27/files#diff-4e22d74821607a2dc683b1c483fe0aa643ff5dc3aab9f76c1e5b4373c0f6bf57">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>usage.py</strong><dd><code>Implement usage metering commands with flexible parsing</code>&nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/commands/usage.py

<ul><li>Implement <code>_parse_date()</code> helper supporting YYYY-MM-DD and relative <br>formats (Nd)<br> <li> Implement <code>_parse_datetime()</code> helper supporting ISO datetime and <br>relative formats (Nh/Nd)<br> <li> Create <code>summary</code> subcommand showing usage across product families with <br>date range filtering<br> <li> Create <code>hosts</code> subcommand displaying hourly host usage metrics<br> <li> Create <code>logs</code> subcommand displaying hourly log ingestion and indexing <br>metrics<br> <li> Create <code>top-avg-metrics</code> subcommand showing top custom metrics by <br>average count<br> <li> Support table and JSON output formats for all subcommands with rich <br>table formatting<br> <li> Handle empty results gracefully with informative messages</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/27/files#diff-67eda3ca27e0f410773601e7d30f22f9877d7cf16aaeb36ce41cde335c6bc713">+337/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_usage.py</strong><dd><code>Add comprehensive tests for usage commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/commands/test_usage.py

<ul><li>Add 13 unit tests covering all four subcommands<br> <li> Test both table and JSON output formats for each subcommand<br> <li> Test empty result handling for all commands<br> <li> Test relative date/time parsing (7d, 24h, 30d)<br> <li> Test default month behavior for top-avg-metrics<br> <li> Verify API calls with correct parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/27/files#diff-811f495d8d3f3500679c324f8c291de624a81215c98aa866f5274fa61ca48aec">+329/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Update test fixtures for usage API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/conftest.py

- Add `client.usage = Mock()` to mock_client fixture for testing


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/27/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

