### PR TITLE
feat(synthetics): add synthetics test management commands

### DIFF
--- a/ddogctl/cli.py
+++ b/ddogctl/cli.py
@@ -79,6 +79,7 @@ from ddogctl.commands.tag import tag
 from ddogctl.commands.downtime import downtime
 from ddogctl.commands.slo import slo
 from ddogctl.commands.dashboard import dashboard
+from ddogctl.commands.synthetics import synthetics
 from ddogctl.commands.completion import completion
 from ddogctl.commands.apply import apply_cmd, diff_cmd
 from ddogctl.commands.config import config
@@ -99,6 +100,7 @@ main.add_command(tag)
 main.add_command(downtime)
 main.add_command(slo)
 main.add_command(dashboard)
+main.add_command(synthetics)
 main.add_command(completion)
 main.add_command(apply_cmd)
 main.add_command(diff_cmd)

--- a/ddogctl/client.py
+++ b/ddogctl/client.py
@@ -13,6 +13,7 @@ from datadog_api_client.v1.api import (
     service_level_objectives_api,
     dashboards_api,
     usage_metering_api,
+    synthetics_api,
 )
 from datadog_api_client.v2.api import (
     logs_api,
@@ -50,6 +51,7 @@ class DatadogClient:
         self.slos = service_level_objectives_api.ServiceLevelObjectivesApi(self.api_client)
         self.dashboards = dashboards_api.DashboardsApi(self.api_client)
         self.usage = usage_metering_api.UsageMeteringApi(self.api_client)
+        self.synthetics = synthetics_api.SyntheticsApi(self.api_client)
 
         # V2 APIs
         self.logs = logs_api.LogsApi(self.api_client)

--- a/ddogctl/commands/synthetics.py
+++ b/ddogctl/commands/synthetics.py
@@ -1,0 +1,221 @@
+"""Synthetics test management commands."""
+
+import click
+import json
+from rich.console import Console
+from rich.table import Table
+from ddogctl.client import get_datadog_client
+from ddogctl.utils.error import handle_api_error
+
+console = Console()
+
+
+@click.group()
+def synthetics():
+    """Synthetics test management commands."""
+    pass
+
+
+@synthetics.command(name="list")
+@click.option("--format", type=click.Choice(["json", "table"]), default="table")
+@handle_api_error
+def list_tests(format):
+    """List all Synthetics tests."""
+    client = get_datadog_client()
+
+    with console.status("[cyan]Fetching Synthetics tests...[/cyan]"):
+        response = client.synthetics.list_tests()
+
+    tests = response.tests if response.tests else []
+
+    if format == "json":
+        output = []
+        for test in tests:
+            output.append(
+                {
+                    "public_id": test.public_id,
+                    "name": test.name,
+                    "type": str(test.type),
+                    "status": str(test.status),
+                    "locations": list(test.locations) if test.locations else [],
+                    "tags": list(test.tags) if test.tags else [],
+                }
+            )
+        print(json.dumps(output, indent=2))
+    else:
+        table = Table(title="Synthetics Tests")
+        table.add_column("Public ID", style="cyan")
+        table.add_column("Name", style="white")
+        table.add_column("Type", style="dim")
+        table.add_column("Status", style="yellow")
+        table.add_column("Locations", style="dim")
+        table.add_column("Tags", style="dim")
+
+        for test in tests:
+            status_style = "green" if str(test.status) == "live" else "red"
+            locations = ", ".join(test.locations) if test.locations else ""
+            tags = ", ".join(test.tags) if test.tags else ""
+            table.add_row(
+                test.public_id,
+                test.name,
+                str(test.type),
+                f"[{status_style}]{test.status}[/{status_style}]",
+                locations,
+                tags,
+            )
+
+        console.print(table)
+        console.print(f"\n[dim]Total tests: {len(tests)}[/dim]")
+
+
+@synthetics.command(name="get")
+@click.argument("public_id")
+@click.option("--format", type=click.Choice(["json", "table"]), default="table")
+@handle_api_error
+def get_test(public_id, format):
+    """Get details for a Synthetics test."""
+    client = get_datadog_client()
+
+    with console.status(f"[cyan]Fetching test {public_id}...[/cyan]"):
+        test = client.synthetics.get_test(public_id=public_id)
+
+    if format == "json":
+        output = {
+            "public_id": test.public_id,
+            "name": test.name,
+            "type": str(test.type),
+            "status": str(test.status),
+            "locations": list(test.locations) if test.locations else [],
+            "tags": list(test.tags) if test.tags else [],
+            "message": test.message if hasattr(test, "message") else "",
+        }
+        print(json.dumps(output, indent=2))
+    else:
+        table = Table(title=f"Synthetics Test: {public_id}")
+        table.add_column("Field", style="cyan")
+        table.add_column("Value", style="white")
+
+        table.add_row("Public ID", test.public_id)
+        table.add_row("Name", test.name)
+        table.add_row("Type", str(test.type))
+        status_style = "green" if str(test.status) == "live" else "red"
+        table.add_row("Status", f"[{status_style}]{test.status}[/{status_style}]")
+        locations = ", ".join(test.locations) if test.locations else "None"
+        table.add_row("Locations", locations)
+        tags = ", ".join(test.tags) if test.tags else "None"
+        table.add_row("Tags", tags)
+        message = test.message if hasattr(test, "message") else ""
+        table.add_row("Message", message or "None")
+
+        console.print(table)
+
+
+@synthetics.command(name="results")
+@click.argument("public_id")
+@click.option("--format", type=click.Choice(["json", "table"]), default="table")
+@handle_api_error
+def get_results(public_id, format):
+    """Get latest results for a Synthetics test."""
+    client = get_datadog_client()
+
+    with console.status(f"[cyan]Fetching results for {public_id}...[/cyan]"):
+        response = client.synthetics.get_api_test_latest_results(public_id=public_id)
+
+    results = response.results if response.results else []
+
+    if format == "json":
+        output = []
+        for result in results:
+            output.append(
+                {
+                    "result_id": getattr(result, "result_id", None),
+                    "status": str(getattr(result, "status", "unknown")),
+                    "check_time": getattr(result, "check_time", None),
+                    "probe_dc": getattr(result, "dc_id", None),
+                }
+            )
+        print(json.dumps(output, indent=2))
+    else:
+        table = Table(title=f"Latest Results: {public_id}")
+        table.add_column("Result ID", style="cyan")
+        table.add_column("Status", style="yellow")
+        table.add_column("Check Time", style="dim")
+        table.add_column("Location", style="dim")
+
+        for result in results:
+            result_id = getattr(result, "result_id", "N/A")
+            status = str(getattr(result, "status", "unknown"))
+            check_time = str(getattr(result, "check_time", "N/A"))
+            probe_dc = getattr(result, "dc_id", "N/A")
+
+            status_style = "green" if status == "0" or status == "passed" else "red"
+            table.add_row(
+                str(result_id),
+                f"[{status_style}]{status}[/{status_style}]",
+                str(check_time),
+                str(probe_dc),
+            )
+
+        console.print(table)
+        console.print(f"\n[dim]Total results: {len(results)}[/dim]")
+
+
+@synthetics.command(name="trigger")
+@click.argument("public_id")
+@click.option("--format", type=click.Choice(["json", "table"]), default="table")
+@handle_api_error
+def trigger_test(public_id, format):
+    """Trigger a Synthetics test execution."""
+    from datadog_api_client.v1.model.synthetics_trigger_body import SyntheticsTriggerBody
+    from datadog_api_client.v1.model.synthetics_trigger_test import SyntheticsTriggerTest
+
+    client = get_datadog_client()
+
+    body = SyntheticsTriggerBody(
+        tests=[SyntheticsTriggerTest(public_id=public_id)],
+    )
+
+    with console.status(f"[cyan]Triggering test {public_id}...[/cyan]"):
+        response = client.synthetics.trigger_tests(body=body)
+
+    triggered = response.results if response.results else []
+    locations = response.locations if hasattr(response, "locations") else []
+
+    if format == "json":
+        output = {
+            "triggered_check_ids": [
+                {
+                    "public_id": getattr(t, "public_id", None),
+                    "result_id": getattr(t, "result_id", None),
+                }
+                for t in triggered
+            ],
+            "locations": (
+                [
+                    {
+                        "id": getattr(loc, "id", None),
+                        "name": getattr(loc, "name", None),
+                    }
+                    for loc in locations
+                ]
+                if locations
+                else []
+            ),
+        }
+        print(json.dumps(output, indent=2))
+    else:
+        console.print(f"[green]Test {public_id} triggered successfully.[/green]")
+
+        if triggered:
+            table = Table(title="Triggered Results")
+            table.add_column("Public ID", style="cyan")
+            table.add_column("Result ID", style="white")
+
+            for t in triggered:
+                table.add_row(
+                    str(getattr(t, "public_id", "N/A")),
+                    str(getattr(t, "result_id", "N/A")),
+                )
+            console.print(table)
+
+        console.print(f"\n[dim]Triggered {len(triggered)} result(s)[/dim]")

--- a/tests/commands/test_synthetics.py
+++ b/tests/commands/test_synthetics.py
@@ -1,0 +1,297 @@
+"""Tests for Synthetics commands."""
+
+import json
+from unittest.mock import Mock, patch
+
+
+def _make_test(
+    public_id, name, test_type="api", status="live", locations=None, tags=None, message=""
+):
+    """Factory to create a mock Synthetics test object."""
+    test = Mock()
+    test.public_id = public_id
+    test.name = name
+    test.type = test_type
+    test.status = status
+    test.locations = locations or ["aws:us-east-1"]
+    test.tags = tags or []
+    test.message = message
+    return test
+
+
+def _make_result(result_id, status, check_time, dc_id):
+    """Factory to create a mock Synthetics result object."""
+    result = Mock()
+    result.result_id = result_id
+    result.status = status
+    result.check_time = check_time
+    result.dc_id = dc_id
+    return result
+
+
+def _make_trigger_result(public_id, result_id):
+    """Factory to create a mock trigger result object."""
+    triggered = Mock()
+    triggered.public_id = public_id
+    triggered.result_id = result_id
+    return triggered
+
+
+# --- list tests ---
+
+
+def test_list_tests_table(mock_client, runner):
+    """Test listing Synthetics tests in table format."""
+    from ddogctl.commands.synthetics import synthetics
+
+    tests = [
+        _make_test("abc-123", "HealthCheck", "api", "live", ["aws:us-east-1"], ["env:prod"]),
+        _make_test("def-456", "LoginFlow", "browser", "paused", ["aws:eu-west-1"], ["env:staging"]),
+    ]
+    mock_client.synthetics.list_tests.return_value = Mock(tests=tests)
+
+    with patch("ddogctl.commands.synthetics.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(synthetics, ["list"])
+
+    assert result.exit_code == 0
+    assert "Synthetics Tests" in result.output
+    assert "abc-123" in result.output
+    assert "HealthCheck" in result.output
+    assert "def-456" in result.output
+    assert "LoginFlow" in result.output
+    assert "Total tests: 2" in result.output
+
+
+def test_list_tests_json(mock_client, runner):
+    """Test listing Synthetics tests in JSON format."""
+    from ddogctl.commands.synthetics import synthetics
+
+    tests = [
+        _make_test("abc-123", "API Health Check", "api", "live", ["aws:us-east-1"], ["env:prod"]),
+        _make_test(
+            "def-456", "Browser Login Flow", "browser", "paused", ["aws:eu-west-1"], ["env:staging"]
+        ),
+    ]
+    mock_client.synthetics.list_tests.return_value = Mock(tests=tests)
+
+    with patch("ddogctl.commands.synthetics.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(synthetics, ["list", "--format", "json"])
+
+    assert result.exit_code == 0
+    output = json.loads(result.output)
+    assert len(output) == 2
+    assert output[0]["public_id"] == "abc-123"
+    assert output[0]["name"] == "API Health Check"
+    assert output[0]["type"] == "api"
+    assert output[0]["status"] == "live"
+    assert output[0]["locations"] == ["aws:us-east-1"]
+    assert output[0]["tags"] == ["env:prod"]
+    assert output[1]["public_id"] == "def-456"
+    assert output[1]["type"] == "browser"
+    assert output[1]["status"] == "paused"
+
+
+def test_list_tests_empty(mock_client, runner):
+    """Test listing Synthetics tests when no tests exist."""
+    from ddogctl.commands.synthetics import synthetics
+
+    mock_client.synthetics.list_tests.return_value = Mock(tests=[])
+
+    with patch("ddogctl.commands.synthetics.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(synthetics, ["list"])
+
+    assert result.exit_code == 0
+    assert "Total tests: 0" in result.output
+
+
+# --- get test ---
+
+
+def test_get_test_table(mock_client, runner):
+    """Test getting a Synthetics test in table format."""
+    from ddogctl.commands.synthetics import synthetics
+
+    test = _make_test(
+        "abc-123",
+        "API Health Check",
+        "api",
+        "live",
+        ["aws:us-east-1", "aws:eu-west-1"],
+        ["env:prod", "team:platform"],
+        message="Alert: API health check failing",
+    )
+    mock_client.synthetics.get_test.return_value = test
+
+    with patch("ddogctl.commands.synthetics.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(synthetics, ["get", "abc-123"])
+
+    assert result.exit_code == 0
+    assert "abc-123" in result.output
+    assert "API Health Check" in result.output
+    assert "api" in result.output
+    assert "live" in result.output
+    assert "aws:us-east-1" in result.output
+    assert "env:prod" in result.output
+    assert "Alert: API health check failing" in result.output
+
+
+def test_get_test_json(mock_client, runner):
+    """Test getting a Synthetics test in JSON format."""
+    from ddogctl.commands.synthetics import synthetics
+
+    test = _make_test(
+        "abc-123",
+        "API Health Check",
+        "api",
+        "live",
+        ["aws:us-east-1"],
+        ["env:prod"],
+        message="Check is failing",
+    )
+    mock_client.synthetics.get_test.return_value = test
+
+    with patch("ddogctl.commands.synthetics.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(synthetics, ["get", "abc-123", "--format", "json"])
+
+    assert result.exit_code == 0
+    output = json.loads(result.output)
+    assert output["public_id"] == "abc-123"
+    assert output["name"] == "API Health Check"
+    assert output["type"] == "api"
+    assert output["status"] == "live"
+    assert output["locations"] == ["aws:us-east-1"]
+    assert output["tags"] == ["env:prod"]
+    assert output["message"] == "Check is failing"
+
+
+def test_get_test_not_found(mock_client, runner):
+    """Test getting a nonexistent Synthetics test returns error exit code."""
+    from ddogctl.commands.synthetics import synthetics
+    from datadog_api_client.exceptions import ApiException
+
+    mock_client.synthetics.get_test.side_effect = ApiException(status=404, reason="Not Found")
+
+    with patch("ddogctl.commands.synthetics.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(synthetics, ["get", "nonexistent-id"])
+
+    assert result.exit_code != 0
+
+
+# --- results tests ---
+
+
+def test_results_table(mock_client, runner):
+    """Test getting Synthetics results in table format."""
+    from ddogctl.commands.synthetics import synthetics
+
+    results = [
+        _make_result("res-001", "0", 1700000000.0, "aws:us-east-1"),
+        _make_result("res-002", "1", 1700003600.0, "aws:eu-west-1"),
+    ]
+    mock_client.synthetics.get_api_test_latest_results.return_value = Mock(results=results)
+
+    with patch("ddogctl.commands.synthetics.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(synthetics, ["results", "abc-123"])
+
+    assert result.exit_code == 0
+    assert "Latest Results: abc-123" in result.output
+    assert "res-001" in result.output
+    assert "res-002" in result.output
+    assert "Total results: 2" in result.output
+
+
+def test_results_json(mock_client, runner):
+    """Test getting Synthetics results in JSON format."""
+    from ddogctl.commands.synthetics import synthetics
+
+    results = [
+        _make_result("res-001", "0", 1700000000.0, "aws:us-east-1"),
+        _make_result("res-002", "1", 1700003600.0, "aws:eu-west-1"),
+    ]
+    mock_client.synthetics.get_api_test_latest_results.return_value = Mock(results=results)
+
+    with patch("ddogctl.commands.synthetics.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(synthetics, ["results", "abc-123", "--format", "json"])
+
+    assert result.exit_code == 0
+    output = json.loads(result.output)
+    assert len(output) == 2
+    assert output[0]["result_id"] == "res-001"
+    assert output[0]["status"] == "0"
+    assert output[0]["check_time"] == 1700000000.0
+    assert output[0]["probe_dc"] == "aws:us-east-1"
+    assert output[1]["result_id"] == "res-002"
+    assert output[1]["status"] == "1"
+
+
+def test_results_empty(mock_client, runner):
+    """Test getting Synthetics results when none exist."""
+    from ddogctl.commands.synthetics import synthetics
+
+    mock_client.synthetics.get_api_test_latest_results.return_value = Mock(results=[])
+
+    with patch("ddogctl.commands.synthetics.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(synthetics, ["results", "abc-123"])
+
+    assert result.exit_code == 0
+    assert "Total results: 0" in result.output
+
+
+# --- trigger tests ---
+
+
+def test_trigger_test_table(mock_client, runner):
+    """Test triggering a Synthetics test in table format."""
+    from ddogctl.commands.synthetics import synthetics
+
+    triggered = [_make_trigger_result("abc-123", "triggered-res-001")]
+    mock_response = Mock(results=triggered)
+    mock_response.locations = []
+    mock_client.synthetics.trigger_tests.return_value = mock_response
+
+    with patch("ddogctl.commands.synthetics.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(synthetics, ["trigger", "abc-123"])
+
+    assert result.exit_code == 0
+    assert "triggered successfully" in result.output
+    assert "abc-123" in result.output
+    assert "triggered-res-001" in result.output
+    assert "Triggered 1 result(s)" in result.output
+
+
+def test_trigger_test_json(mock_client, runner):
+    """Test triggering a Synthetics test in JSON format."""
+    from ddogctl.commands.synthetics import synthetics
+
+    triggered = [_make_trigger_result("abc-123", "triggered-res-001")]
+    mock_response = Mock(results=triggered)
+    mock_response.locations = []
+    mock_client.synthetics.trigger_tests.return_value = mock_response
+
+    with patch("ddogctl.commands.synthetics.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(synthetics, ["trigger", "abc-123", "--format", "json"])
+
+    assert result.exit_code == 0
+    output = json.loads(result.output)
+    assert len(output["triggered_check_ids"]) == 1
+    assert output["triggered_check_ids"][0]["public_id"] == "abc-123"
+    assert output["triggered_check_ids"][0]["result_id"] == "triggered-res-001"
+
+
+def test_trigger_test_calls_api_correctly(mock_client, runner):
+    """Test that trigger passes the correct body to the API."""
+    from ddogctl.commands.synthetics import synthetics
+
+    triggered = [_make_trigger_result("xyz-789", "res-999")]
+    mock_response = Mock(results=triggered)
+    mock_response.locations = []
+    mock_client.synthetics.trigger_tests.return_value = mock_response
+
+    with patch("ddogctl.commands.synthetics.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(synthetics, ["trigger", "xyz-789"])
+
+    assert result.exit_code == 0
+    mock_client.synthetics.trigger_tests.assert_called_once()
+    call_kwargs = mock_client.synthetics.trigger_tests.call_args
+    body = call_kwargs.kwargs["body"]
+    assert body.tests[0].public_id == "xyz-789"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ def mock_client():
     client.incidents = Mock()
     client.users = Mock()
     client.usage = Mock()
+    client.synthetics = Mock()
     return client
 
 


### PR DESCRIPTION
### **User description**
## Summary
- Add `ddogctl synthetics` command group with list, get, results, and trigger subcommands
- Support for API/browser test management via SyntheticsApi (v1)
- Rich table and JSON output formats

## Test plan
- [x] Unit tests for all subcommands (table + JSON formats)
- [x] Empty results handling
- [x] Error handling (404 not found)
- [x] Trigger API body construction verified
- [x] pytest, black, ruff all pass (598 tests, 0 failures)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `ddogctl synthetics` command group with list, get, results, trigger subcommands

- Support API/browser test management via SyntheticsApi (v1)

- Implement rich table and JSON output formats for all subcommands

- Comprehensive test coverage for all synthetics operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["CLI Entry Point"]
  Client["Datadog Client"]
  SynthAPI["SyntheticsApi"]
  Commands["Synthetics Commands"]
  
  CLI -- "imports synthetics" --> Commands
  Client -- "adds synthetics_api" --> SynthAPI
  Commands -- "uses client.synthetics" --> SynthAPI
  Commands -- "list/get/results/trigger" --> Output["Table/JSON Output"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.py</strong><dd><code>Register synthetics command group</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/cli.py

<ul><li>Import <code>synthetics</code> command group from <code>ddogctl.commands.synthetics</code><br> <li> Register <code>synthetics</code> command with main CLI group</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/28/files#diff-1ca1a58dd47b18afff9b729ec6430c335581acb24899da2e49951588191ea17e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Add SyntheticsApi client integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/client.py

<ul><li>Import <code>synthetics_api</code> from datadog_api_client.v1.api<br> <li> Initialize <code>self.synthetics</code> with SyntheticsApi instance in <br>DatadogClient</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/28/files#diff-4e22d74821607a2dc683b1c483fe0aa643ff5dc3aab9f76c1e5b4373c0f6bf57">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>synthetics.py</strong><dd><code>Synthetics test management commands implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/commands/synthetics.py

<ul><li>Implement <code>list</code> subcommand to list all synthetics tests with table/JSON <br>output<br> <li> Implement <code>get</code> subcommand to retrieve test details by public_id<br> <li> Implement <code>results</code> subcommand to fetch latest test results<br> <li> Implement <code>trigger</code> subcommand to execute tests with proper API body <br>construction<br> <li> Support dual output formats (table with rich styling, JSON) for all <br>commands<br> <li> Handle empty results and optional attributes gracefully</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/28/files#diff-cde680e25fbe25ac474610ddc2949003bb66626e732a72f40b2770ec9e87609b">+221/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_synthetics.py</strong><dd><code>Comprehensive synthetics command test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/commands/test_synthetics.py

<ul><li>Add factory functions for creating mock test, result, and trigger <br>objects<br> <li> Test <code>list</code> command with table/JSON formats and empty results<br> <li> Test <code>get</code> command with table/JSON formats and 404 error handling<br> <li> Test <code>results</code> command with table/JSON formats and empty results<br> <li> Test <code>trigger</code> command with table/JSON formats and API body verification<br> <li> Total of 13 test cases covering all subcommands and edge cases</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/28/files#diff-41f4a68528cd9f49757c36a36387bd7ec2c057cc5100516cbd6f205deef14c8a">+297/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Add synthetics mock to test fixtures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/conftest.py

<ul><li>Add <code>client.synthetics = Mock()</code> to mock_client fixture for test <br>isolation</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/28/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

