### PR TITLE
feat(rum): add RUM application monitoring commands

### DIFF
--- a/ddogctl/cli.py
+++ b/ddogctl/cli.py
@@ -80,6 +80,7 @@ from ddogctl.commands.downtime import downtime
 from ddogctl.commands.slo import slo
 from ddogctl.commands.dashboard import dashboard
 from ddogctl.commands.synthetics import synthetics
+from ddogctl.commands.rum import rum
 from ddogctl.commands.completion import completion
 from ddogctl.commands.apply import apply_cmd, diff_cmd
 from ddogctl.commands.config import config
@@ -101,6 +102,7 @@ main.add_command(downtime)
 main.add_command(slo)
 main.add_command(dashboard)
 main.add_command(synthetics)
+main.add_command(rum)
 main.add_command(completion)
 main.add_command(apply_cmd)
 main.add_command(diff_cmd)

--- a/ddogctl/client.py
+++ b/ddogctl/client.py
@@ -21,6 +21,7 @@ from datadog_api_client.v2.api import (
     service_definition_api,
     incidents_api,
     users_api,
+    rum_api,
 )
 from ddogctl.config import DatadogConfig
 
@@ -59,6 +60,7 @@ class DatadogClient:
         self.service_definitions = service_definition_api.ServiceDefinitionApi(self.api_client)
         self.incidents = incidents_api.IncidentsApi(self.api_client)
         self.users = users_api.UsersApi(self.api_client)
+        self.rum = rum_api.RUMApi(self.api_client)
 
     def __enter__(self):
         return self

--- a/ddogctl/commands/rum.py
+++ b/ddogctl/commands/rum.py
@@ -1,0 +1,198 @@
+"""RUM (Real User Monitoring) commands."""
+
+import click
+import json
+from datetime import datetime
+from rich.console import Console
+from rich.table import Table
+from ddogctl.client import get_datadog_client
+from ddogctl.utils.error import handle_api_error
+from ddogctl.utils.time import parse_time_range
+
+console = Console()
+
+EVENT_TYPE_COLORS = {
+    "error": "red",
+    "action": "yellow",
+    "view": "cyan",
+    "resource": "dim",
+    "long_task": "magenta",
+}
+
+
+def _format_rum_event(event):
+    """Extract fields from a RUM event."""
+    attrs = event.attributes
+    return {
+        "id": event.id,
+        "type": getattr(attrs, "type", getattr(event, "type", "unknown")),
+        "timestamp": str(attrs.timestamp) if hasattr(attrs, "timestamp") else None,
+        "attributes": attrs.attributes if hasattr(attrs, "attributes") else {},
+        "tags": attrs.tags if hasattr(attrs, "tags") else [],
+    }
+
+
+@click.group()
+def rum():
+    """RUM (Real User Monitoring) commands."""
+    pass
+
+
+@rum.command(name="events")
+@click.option("--query", default="*", help="RUM event query (default: *)")
+@click.option("--from", "from_time", default="1h", help="Start time (e.g., 1h, 24h, 7d)")
+@click.option("--to", "to_time", default="now", help="End time")
+@click.option("--limit", default=50, type=int, help="Max events to return (max: 1000)")
+@click.option("--format", type=click.Choice(["json", "table"]), default="table")
+@handle_api_error
+def list_events(query, from_time, to_time, limit, format):
+    """Search RUM events.
+
+    Rate limit: 300 requests/hour for RUM API.
+    """
+    client = get_datadog_client()
+
+    # Parse time range
+    from_ts, to_ts = parse_time_range(from_time, to_time)
+    from_str = datetime.fromtimestamp(from_ts).isoformat() + "Z"
+    to_str = datetime.fromtimestamp(to_ts).isoformat() + "Z"
+
+    with console.status("[cyan]Searching RUM events...[/cyan]"):
+        response = client.rum.list_rum_events(
+            filter_query=query,
+            filter_from=from_str,
+            filter_to=to_str,
+            page_limit=limit,
+        )
+
+    events = response.data if response.data else []
+
+    if format == "json":
+        output = [_format_rum_event(event) for event in events]
+        print(json.dumps(output, indent=2, default=str))
+    else:
+        table = Table(title="RUM Events")
+        table.add_column("Time", style="dim", width=20)
+        table.add_column("Type", width=12)
+        table.add_column("ID", style="cyan", width=18)
+        table.add_column("Details", style="white")
+
+        for event in events:
+            attrs = event.attributes
+            time_str = str(attrs.timestamp) if hasattr(attrs, "timestamp") else "N/A"
+            if hasattr(attrs, "timestamp") and hasattr(attrs.timestamp, "strftime"):
+                time_str = attrs.timestamp.strftime("%Y-%m-%d %H:%M:%S")
+
+            event_type = getattr(attrs, "type", getattr(event, "type", "unknown"))
+            color = EVENT_TYPE_COLORS.get(str(event_type), "white")
+            type_styled = f"[{color}]{event_type}[/{color}]"
+
+            event_attrs = attrs.attributes if hasattr(attrs, "attributes") else {}
+            details = str(event_attrs)[:60] if event_attrs else ""
+
+            table.add_row(
+                time_str,
+                type_styled,
+                str(event.id)[:16] + ".." if len(str(event.id)) > 16 else str(event.id),
+                details,
+            )
+
+        console.print(table)
+        console.print(f"\n[dim]Total events: {len(events)}[/dim]")
+
+
+@rum.command(name="analytics")
+@click.option("--query", default="*", help="RUM event query (default: *)")
+@click.option(
+    "--metric",
+    default="count",
+    type=click.Choice(["count", "p99", "avg"]),
+    help="Metric (count, p99, avg)",
+)
+@click.option("--group-by", help="Group by field (e.g., @type, @view.url, @geo.country)")
+@click.option("--from", "from_time", default="1h", help="Start time (e.g., 1h, 24h, 7d)")
+@click.option("--to", "to_time", default="now", help="End time")
+@click.option("--format", type=click.Choice(["json", "table"]), default="table")
+@handle_api_error
+def analytics(query, metric, group_by, from_time, to_time, format):
+    """RUM analytics and aggregations.
+
+    Compute metrics (count, p99, avg) across RUM events, optionally grouped by dimensions.
+    """
+    client = get_datadog_client()
+
+    # Parse time range
+    from_ts, to_ts = parse_time_range(from_time, to_time)
+    from_str = datetime.fromtimestamp(from_ts).isoformat() + "Z"
+    to_str = datetime.fromtimestamp(to_ts).isoformat() + "Z"
+
+    # Build filter
+    filter_dict = {"query": query, "from": from_str, "to": to_str}
+
+    # Configure compute
+    if metric == "count":
+        compute_dict = {"aggregation": "count"}
+    elif metric == "p99":
+        compute_dict = {"aggregation": "pc99", "metric": "@view.time_spent"}
+    elif metric == "avg":
+        compute_dict = {"aggregation": "avg", "metric": "@view.time_spent"}
+    else:
+        compute_dict = {"aggregation": "count"}
+
+    # Configure group-by
+    group_by_list = [{"facet": group_by}] if group_by else []
+
+    # Build request body
+    body = {
+        "filter": filter_dict,
+        "compute": [compute_dict],
+        "group_by": group_by_list,
+    }
+
+    with console.status("[cyan]Computing RUM analytics...[/cyan]"):
+        response = client.rum.aggregate_rum_events(body=body)
+
+    buckets = response.data.buckets if response.data else []
+
+    if format == "json":
+        output = []
+        for bucket in buckets:
+            result = bucket.by.copy() if bucket.by else {}
+            if bucket.computes:
+                value = list(bucket.computes.values())[0]
+                # Convert duration from ns to ms for time metrics
+                if metric in ["p99", "avg"]:
+                    result[metric] = round(value / 1_000_000, 2)
+                else:
+                    result[metric] = value
+            output.append(result)
+        print(json.dumps(output, indent=2))
+    else:
+        title = f"RUM Analytics ({metric})"
+        if group_by:
+            title += f" by {group_by}"
+
+        table = Table(title=title)
+        if group_by:
+            table.add_column(group_by.replace("@", ""), style="cyan")
+
+        metric_label = metric.upper()
+        if metric in ["p99", "avg"]:
+            metric_label += " (ms)"
+        table.add_column(metric_label, justify="right", style="yellow")
+
+        for bucket in buckets:
+            row = []
+            if bucket.by and group_by:
+                row.append(str(bucket.by.get(group_by, "N/A")))
+
+            if bucket.computes:
+                value = list(bucket.computes.values())[0]
+                if metric in ["p99", "avg"]:
+                    value = value / 1_000_000
+                row.append(f"{value:.2f}")
+
+            table.add_row(*row)
+
+        console.print(table)
+        console.print(f"\n[dim]Total groups: {len(buckets)}[/dim]")

--- a/tests/commands/test_rum.py
+++ b/tests/commands/test_rum.py
@@ -1,0 +1,282 @@
+"""Tests for RUM commands."""
+
+import json
+from datetime import datetime
+from unittest.mock import Mock, patch
+from tests.conftest import create_mock_rum_event
+
+# Events command tests
+
+
+def test_rum_events_table(mock_client, runner):
+    """Test events table output has correct headers and content."""
+    from ddogctl.commands.rum import rum
+
+    now = datetime.now()
+    mock_events = [
+        create_mock_rum_event("evt-001", "view", now, {"url": "/home"}),
+        create_mock_rum_event("evt-002", "action", now, {"name": "click"}),
+    ]
+    mock_response = Mock(data=mock_events)
+    mock_client.rum.list_rum_events.return_value = mock_response
+
+    with patch("ddogctl.commands.rum.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(rum, ["events"])
+
+        assert result.exit_code == 0
+        assert "RUM Events" in result.output
+        assert "Time" in result.output
+        assert "Type" in result.output
+        assert "ID" in result.output
+        assert "Total events: 2" in result.output
+
+
+def test_rum_events_json(mock_client, runner):
+    """Test events JSON output has expected fields."""
+    from ddogctl.commands.rum import rum
+
+    now = datetime.now()
+    mock_events = [
+        create_mock_rum_event("evt-001", "view", now, {"url": "/home"}),
+    ]
+    mock_response = Mock(data=mock_events)
+    mock_client.rum.list_rum_events.return_value = mock_response
+
+    with patch("ddogctl.commands.rum.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(rum, ["events", "--format", "json"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert len(output) == 1
+        assert output[0]["id"] == "evt-001"
+        assert output[0]["type"] == "view"
+        assert "timestamp" in output[0]
+        assert "attributes" in output[0]
+
+
+def test_rum_events_empty(mock_client, runner):
+    """Test events with no results shows total 0."""
+    from ddogctl.commands.rum import rum
+
+    mock_response = Mock(data=[])
+    mock_client.rum.list_rum_events.return_value = mock_response
+
+    with patch("ddogctl.commands.rum.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(rum, ["events"])
+
+        assert result.exit_code == 0
+        assert "Total events: 0" in result.output
+
+
+def test_rum_events_with_query(mock_client, runner):
+    """Test events with --query passes query to API."""
+    from ddogctl.commands.rum import rum
+
+    mock_response = Mock(data=[])
+    mock_client.rum.list_rum_events.return_value = mock_response
+
+    with patch("ddogctl.commands.rum.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(rum, ["events", "--query", "@type:error"])
+
+        assert result.exit_code == 0
+        call_kwargs = mock_client.rum.list_rum_events.call_args.kwargs
+        assert call_kwargs["filter_query"] == "@type:error"
+
+
+def test_rum_events_with_time_range(mock_client, runner):
+    """Test events with --from 24h is accepted."""
+    from ddogctl.commands.rum import rum
+
+    mock_response = Mock(data=[])
+    mock_client.rum.list_rum_events.return_value = mock_response
+
+    with patch("ddogctl.commands.rum.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(rum, ["events", "--from", "24h"])
+
+        assert result.exit_code == 0
+        mock_client.rum.list_rum_events.assert_called_once()
+
+
+def test_rum_events_with_limit(mock_client, runner):
+    """Test events respects --limit parameter."""
+    from ddogctl.commands.rum import rum
+
+    mock_response = Mock(data=[])
+    mock_client.rum.list_rum_events.return_value = mock_response
+
+    with patch("ddogctl.commands.rum.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(rum, ["events", "--limit", "10"])
+
+        assert result.exit_code == 0
+        call_kwargs = mock_client.rum.list_rum_events.call_args.kwargs
+        assert call_kwargs["page_limit"] == 10
+
+
+# Analytics command tests
+
+
+def test_rum_analytics_table(mock_client, runner):
+    """Test analytics table output has correct columns."""
+    from ddogctl.commands.rum import rum
+
+    class MockBucket:
+        def __init__(self, event_type, count):
+            self.by = {"@type": event_type}
+            self.computes = {"c0": count}
+
+    mock_buckets = [
+        MockBucket("view", 1500),
+        MockBucket("action", 800),
+    ]
+    mock_response = Mock(data=Mock(buckets=mock_buckets))
+    mock_client.rum.aggregate_rum_events.return_value = mock_response
+
+    with patch("ddogctl.commands.rum.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(rum, ["analytics", "--metric", "count", "--group-by", "@type"])
+
+        assert result.exit_code == 0
+        assert "RUM Analytics" in result.output
+        assert "COUNT" in result.output
+        assert "type" in result.output
+        assert "view" in result.output
+        assert "1500" in result.output
+        assert "Total groups: 2" in result.output
+
+
+def test_rum_analytics_json(mock_client, runner):
+    """Test analytics JSON output has expected structure."""
+    from ddogctl.commands.rum import rum
+
+    class MockBucket:
+        def __init__(self, event_type, count):
+            self.by = {"@type": event_type}
+            self.computes = {"c0": count}
+
+    mock_buckets = [
+        MockBucket("view", 1500),
+        MockBucket("action", 800),
+    ]
+    mock_response = Mock(data=Mock(buckets=mock_buckets))
+    mock_client.rum.aggregate_rum_events.return_value = mock_response
+
+    with patch("ddogctl.commands.rum.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            rum,
+            ["analytics", "--metric", "count", "--group-by", "@type", "--format", "json"],
+        )
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert len(output) == 2
+        assert output[0]["@type"] == "view"
+        assert output[0]["count"] == 1500
+        assert output[1]["@type"] == "action"
+        assert output[1]["count"] == 800
+
+
+def test_rum_analytics_p99(mock_client, runner):
+    """Test analytics with p99 metric converts ns to ms."""
+    from ddogctl.commands.rum import rum
+
+    class MockBucket:
+        def __init__(self, url, p99_ns):
+            self.by = {"@view.url": url}
+            self.computes = {"c0": p99_ns}
+
+    mock_buckets = [
+        MockBucket("/home", 2_500_000_000),  # 2500ms
+    ]
+    mock_response = Mock(data=Mock(buckets=mock_buckets))
+    mock_client.rum.aggregate_rum_events.return_value = mock_response
+
+    with patch("ddogctl.commands.rum.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            rum,
+            [
+                "analytics",
+                "--metric",
+                "p99",
+                "--group-by",
+                "@view.url",
+                "--format",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert len(output) == 1
+        assert output[0]["p99"] == 2500.0
+
+
+def test_rum_analytics_avg(mock_client, runner):
+    """Test analytics with avg metric converts ns to ms."""
+    from ddogctl.commands.rum import rum
+
+    class MockBucket:
+        def __init__(self, country, avg_ns):
+            self.by = {"@geo.country": country}
+            self.computes = {"c0": avg_ns}
+
+    mock_buckets = [
+        MockBucket("US", 500_000_000),  # 500ms
+        MockBucket("EU", 800_000_000),  # 800ms
+    ]
+    mock_response = Mock(data=Mock(buckets=mock_buckets))
+    mock_client.rum.aggregate_rum_events.return_value = mock_response
+
+    with patch("ddogctl.commands.rum.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(
+            rum,
+            [
+                "analytics",
+                "--metric",
+                "avg",
+                "--group-by",
+                "@geo.country",
+                "--format",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert len(output) == 2
+        assert output[0]["avg"] == 500.0
+        assert output[1]["avg"] == 800.0
+
+
+def test_rum_analytics_without_groupby(mock_client, runner):
+    """Test analytics without group-by returns single aggregate."""
+    from ddogctl.commands.rum import rum
+
+    class MockBucket:
+        def __init__(self, count):
+            self.by = {}
+            self.computes = {"c0": count}
+
+    mock_buckets = [MockBucket(12345)]
+    mock_response = Mock(data=Mock(buckets=mock_buckets))
+    mock_client.rum.aggregate_rum_events.return_value = mock_response
+
+    with patch("ddogctl.commands.rum.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(rum, ["analytics", "--metric", "count", "--format", "json"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert len(output) == 1
+        assert output[0]["count"] == 12345
+
+
+def test_rum_analytics_empty(mock_client, runner):
+    """Test analytics with no results shows total 0."""
+    from ddogctl.commands.rum import rum
+
+    mock_response = Mock(data=Mock(buckets=[]))
+    mock_client.rum.aggregate_rum_events.return_value = mock_response
+
+    with patch("ddogctl.commands.rum.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(rum, ["analytics", "--metric", "count"])
+
+        assert result.exit_code == 0
+        assert "Total groups: 0" in result.output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ def mock_client():
     client.users = Mock()
     client.usage = Mock()
     client.synthetics = Mock()
+    client.rum = Mock()
     return client
 
 
@@ -331,6 +332,37 @@ def create_mock_log(message, service, status, timestamp, attributes=None, trace_
             }
 
     return MockLog()
+
+
+# RUM factory functions
+
+
+def create_mock_rum_event(event_id, event_type, timestamp, attributes=None, tags=None):
+    """Factory for mock RUM event objects.
+
+    Args:
+        event_id: Event ID (string)
+        event_type: Event type (e.g., "view", "action", "error", "resource", "long_task")
+        timestamp: Event timestamp (datetime)
+        attributes: Dict of event attributes (default: {})
+        tags: List of tags (default: [])
+
+    Returns:
+        Mock RUM event object
+    """
+
+    class MockRUMEvent:
+        def __init__(self):
+            self.id = event_id
+            self.type = event_type
+            self.attributes = Mock(
+                type=event_type,
+                timestamp=timestamp,
+                attributes=attributes or {},
+                tags=tags or [],
+            )
+
+    return MockRUMEvent()
 
 
 # DBM factory functions


### PR DESCRIPTION
### **User description**
## Summary
- Add `ddogctl rum` command group with `events` and `analytics` subcommands
- `rum events`: search RUM events with query, time range, and limit options via `RUMApi.list_rum_events`
- `rum analytics`: aggregate RUM events with count/p99/avg metrics and group-by via `RUMApi.aggregate_rum_events`
- Rich table and JSON output formats for both subcommands

## Test plan
- [x] 12 unit tests covering all subcommands (events table/json, analytics table/json/p99/avg)
- [x] Empty results handling tested
- [x] Query and time range parameter passing verified
- [x] Full test suite passes (598 tests)
- [x] black formatting passes
- [x] ruff linting passes


___

### **PR Type**
Enhancement


___

### **Description**
- Add `rum` command group with `events` and `analytics` subcommands

- `events` subcommand searches RUM events with query, time range, and limit options

- `analytics` subcommand aggregates RUM events with count/p99/avg metrics and group-by support

- Support both table and JSON output formats for both subcommands

- Comprehensive test coverage with 12 unit tests for all functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI Entry Point"] -->|imports| B["rum command group"]
  B -->|subcommand| C["events: Search RUM events"]
  B -->|subcommand| D["analytics: Aggregate RUM events"]
  C -->|uses| E["RUMApi.list_rum_events"]
  D -->|uses| F["RUMApi.aggregate_rum_events"]
  E -->|outputs| G["Table/JSON format"]
  F -->|outputs| G
  H["DatadogClient"] -->|initializes| I["RUMApi instance"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.py</strong><dd><code>Register RUM command group with CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/cli.py

<ul><li>Import new <code>rum</code> command group from <code>ddogctl.commands.rum</code><br> <li> Register <code>rum</code> command with main CLI group</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/29/files#diff-1ca1a58dd47b18afff9b729ec6430c335581acb24899da2e49951588191ea17e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Add RUM API client initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/client.py

<ul><li>Import <code>rum_api</code> from <code>datadog_api_client.v2.api</code><br> <li> Initialize <code>RUMApi</code> instance in DatadogClient constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/29/files#diff-4e22d74821607a2dc683b1c483fe0aa643ff5dc3aab9f76c1e5b4373c0f6bf57">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rum.py</strong><dd><code>Implement RUM events and analytics commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ddogctl/commands/rum.py

<ul><li>Implement <code>rum</code> command group with two subcommands<br> <li> <code>events</code> subcommand: search RUM events with query, time range, and limit <br>filters; supports table and JSON output<br> <li> <code>analytics</code> subcommand: aggregate RUM events with count/p99/avg metrics; <br>supports optional group-by dimension and both output formats<br> <li> Helper function <code>_format_rum_event</code> to extract and structure event data<br> <li> Event type color mapping for enhanced table visualization</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/29/files#diff-42fb0fec54eb24aa1e1533868b9c4f6da8062097ccb17f2598529bf1315e97f5">+198/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_rum.py</strong><dd><code>Add comprehensive RUM command tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/commands/test_rum.py

<ul><li>12 comprehensive unit tests covering both <code>events</code> and <code>analytics</code> <br>subcommands<br> <li> Tests for table and JSON output formats for both commands<br> <li> Tests for query parameters, time range, and limit options<br> <li> Tests for metric types (count, p99, avg) with nanosecond to <br>millisecond conversion<br> <li> Tests for group-by functionality and empty result handling</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/29/files#diff-ad05f832f695ea98b24ef43ee5eb05140ec5554820ca4808fffb909b22be562d">+282/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Add RUM mock and event factory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/conftest.py

<ul><li>Add <code>rum</code> mock to <code>mock_client</code> fixture<br> <li> Implement <code>create_mock_rum_event</code> factory function for creating mock RUM <br>event objects with id, type, timestamp, attributes, and tags</ul>


</details>


  </td>
  <td><a href="https://github.com/srgfrancisco/ddogctl/pull/29/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

