### PR TITLE
feat(ci): add CI Visibility commands

### DIFF
--- a/ddogctl/cli.py
+++ b/ddogctl/cli.py
@@ -87,6 +87,7 @@ from ddogctl.commands.config import config
 from ddogctl.commands.incident import incident
 from ddogctl.commands.user import user
 from ddogctl.commands.usage import usage
+from ddogctl.commands.ci import ci
 
 main.add_command(monitor)
 main.add_command(metric)
@@ -110,6 +111,7 @@ main.add_command(config)
 main.add_command(incident)
 main.add_command(user)
 main.add_command(usage)
+main.add_command(ci)
 
 
 if __name__ == "__main__":

--- a/ddogctl/client.py
+++ b/ddogctl/client.py
@@ -22,6 +22,8 @@ from datadog_api_client.v2.api import (
     incidents_api,
     users_api,
     rum_api,
+    ci_visibility_pipelines_api,
+    ci_visibility_tests_api,
 )
 from ddogctl.config import DatadogConfig
 
@@ -61,6 +63,8 @@ class DatadogClient:
         self.incidents = incidents_api.IncidentsApi(self.api_client)
         self.users = users_api.UsersApi(self.api_client)
         self.rum = rum_api.RUMApi(self.api_client)
+        self.ci_pipelines = ci_visibility_pipelines_api.CIVisibilityPipelinesApi(self.api_client)
+        self.ci_tests = ci_visibility_tests_api.CIVisibilityTestsApi(self.api_client)
 
     def __enter__(self):
         return self

--- a/ddogctl/commands/ci.py
+++ b/ddogctl/commands/ci.py
@@ -1,0 +1,251 @@
+"""CI Visibility commands."""
+
+import click
+import json
+from datetime import datetime
+from rich.console import Console
+from rich.table import Table
+from ddogctl.client import get_datadog_client
+from ddogctl.utils.error import handle_api_error
+from ddogctl.utils.time import parse_time_range
+
+console = Console()
+
+STATUS_COLORS = {
+    "success": "green",
+    "error": "red",
+    "failed": "red",
+    "canceled": "yellow",
+    "skipped": "dim",
+    "running": "cyan",
+    "blocked": "yellow",
+    "pass": "green",
+    "fail": "red",
+}
+
+
+def _extract_event_fields(event):
+    """Extract common fields from a CI event."""
+    attrs = event.attributes
+    # attributes is a dict-like object; use getattr for safety
+    result = {
+        "id": event.id,
+        "type": getattr(event, "type", None),
+    }
+    # Flatten known attribute fields
+    if hasattr(attrs, "attributes"):
+        inner = attrs.attributes
+        if isinstance(inner, dict):
+            result.update(inner)
+        elif hasattr(inner, "to_dict"):
+            result.update(inner.to_dict())
+    return result
+
+
+@click.group()
+def ci():
+    """CI Visibility commands (pipelines and tests)."""
+    pass
+
+
+@ci.command(name="pipelines")
+@click.option("--query", default="*", help="Search query for pipeline events")
+@click.option("--from", "from_time", default="1h", help="Start time (e.g., 1h, 24h, 7d)")
+@click.option("--to", "to_time", default="now", help="End time")
+@click.option("--limit", default=50, type=int, help="Max events to return (max: 1000)")
+@click.option("--format", type=click.Choice(["json", "table"]), default="table")
+@handle_api_error
+def pipelines(query, from_time, to_time, limit, format):
+    """Search CI pipeline events.
+
+    Query pipeline execution events from CI Visibility.
+    """
+    client = get_datadog_client()
+
+    from_ts, to_ts = parse_time_range(from_time, to_time)
+    from_dt = datetime.fromtimestamp(from_ts)
+    to_dt = datetime.fromtimestamp(to_ts)
+
+    with console.status("[cyan]Searching CI pipeline events...[/cyan]"):
+        response = client.ci_pipelines.list_ci_app_pipeline_events(
+            filter_query=query,
+            filter_from=from_dt,
+            filter_to=to_dt,
+            page_limit=limit,
+        )
+
+    events = response.data if response.data else []
+
+    if format == "json":
+        output = [_extract_event_fields(e) for e in events]
+        print(json.dumps(output, indent=2, default=str))
+    else:
+        table = Table(title="CI Pipeline Events")
+        table.add_column("ID", style="cyan", width=20)
+        table.add_column("Pipeline", style="white", min_width=20)
+        table.add_column("Status", width=10)
+        table.add_column("Duration", justify="right", style="yellow", width=12)
+        table.add_column("Branch", style="dim", width=20)
+
+        for event in events:
+            fields = _extract_event_fields(event)
+            pipeline_name = str(fields.get("name", fields.get("pipeline_name", "N/A")))
+            status = str(fields.get("status", "N/A"))
+            color = STATUS_COLORS.get(status.lower(), "white")
+            status_styled = f"[{color}]{status}[/{color}]"
+
+            # Duration may be in nanoseconds
+            duration_raw = fields.get("duration", None)
+            if duration_raw is not None:
+                duration_ms = duration_raw / 1_000_000
+                if duration_ms >= 1000:
+                    duration_str = f"{duration_ms / 1000:.1f}s"
+                else:
+                    duration_str = f"{duration_ms:.0f}ms"
+            else:
+                duration_str = "N/A"
+
+            branch = str(
+                fields.get("git", {}).get("branch", "")
+                if isinstance(fields.get("git"), dict)
+                else fields.get("branch", "N/A")
+            )
+
+            event_id = str(event.id or "N/A")
+            if len(event_id) > 18:
+                event_id = event_id[:16] + ".."
+
+            table.add_row(event_id, pipeline_name, status_styled, duration_str, branch)
+
+        console.print(table)
+        console.print(f"\n[dim]Total pipeline events: {len(events)}[/dim]")
+
+
+@ci.command(name="tests")
+@click.option("--query", default="*", help="Search query for test events")
+@click.option("--from", "from_time", default="1h", help="Start time (e.g., 1h, 24h, 7d)")
+@click.option("--to", "to_time", default="now", help="End time")
+@click.option("--limit", default=50, type=int, help="Max events to return (max: 1000)")
+@click.option("--format", type=click.Choice(["json", "table"]), default="table")
+@handle_api_error
+def tests(query, from_time, to_time, limit, format):
+    """Search CI test events.
+
+    Query test execution events from CI Visibility.
+    """
+    client = get_datadog_client()
+
+    from_ts, to_ts = parse_time_range(from_time, to_time)
+    from_dt = datetime.fromtimestamp(from_ts)
+    to_dt = datetime.fromtimestamp(to_ts)
+
+    with console.status("[cyan]Searching CI test events...[/cyan]"):
+        response = client.ci_tests.list_ci_app_test_events(
+            filter_query=query,
+            filter_from=from_dt,
+            filter_to=to_dt,
+            page_limit=limit,
+        )
+
+    events = response.data if response.data else []
+
+    if format == "json":
+        output = [_extract_event_fields(e) for e in events]
+        print(json.dumps(output, indent=2, default=str))
+    else:
+        table = Table(title="CI Test Events")
+        table.add_column("ID", style="cyan", width=20)
+        table.add_column("Test Name", style="white", min_width=25)
+        table.add_column("Suite", style="dim", width=20)
+        table.add_column("Status", width=10)
+        table.add_column("Duration", justify="right", style="yellow", width=12)
+
+        for event in events:
+            fields = _extract_event_fields(event)
+            test_name = str(fields.get("name", fields.get("test_name", "N/A")))
+            suite = str(fields.get("suite", fields.get("test_suite", "N/A")))
+            status = str(fields.get("status", "N/A"))
+            color = STATUS_COLORS.get(status.lower(), "white")
+            status_styled = f"[{color}]{status}[/{color}]"
+
+            duration_raw = fields.get("duration", None)
+            if duration_raw is not None:
+                duration_ms = duration_raw / 1_000_000
+                if duration_ms >= 1000:
+                    duration_str = f"{duration_ms / 1000:.1f}s"
+                else:
+                    duration_str = f"{duration_ms:.0f}ms"
+            else:
+                duration_str = "N/A"
+
+            event_id = str(event.id or "N/A")
+            if len(event_id) > 18:
+                event_id = event_id[:16] + ".."
+
+            table.add_row(event_id, test_name, suite, status_styled, duration_str)
+
+        console.print(table)
+        console.print(f"\n[dim]Total test events: {len(events)}[/dim]")
+
+
+@ci.command(name="pipeline-details")
+@click.argument("pipeline_id")
+@click.option("--format", type=click.Choice(["json", "table"]), default="table")
+@handle_api_error
+def pipeline_details(pipeline_id, format):
+    """Get details for a specific CI pipeline run.
+
+    Searches for pipeline events matching the given pipeline ID.
+    """
+    client = get_datadog_client()
+
+    with console.status(f"[cyan]Fetching pipeline {pipeline_id}...[/cyan]"):
+        response = client.ci_pipelines.list_ci_app_pipeline_events(
+            filter_query=f"@ci.pipeline.id:{pipeline_id}",
+            page_limit=100,
+        )
+
+    events = response.data if response.data else []
+
+    if not events:
+        console.print(f"[yellow]No events found for pipeline {pipeline_id}.[/yellow]")
+        return
+
+    if format == "json":
+        output = [_extract_event_fields(e) for e in events]
+        print(json.dumps(output, indent=2, default=str))
+    else:
+        table = Table(title=f"Pipeline Details: {pipeline_id}")
+        table.add_column("ID", style="cyan", width=20)
+        table.add_column("Name", style="white", min_width=20)
+        table.add_column("Status", width=10)
+        table.add_column("Duration", justify="right", style="yellow", width=12)
+        table.add_column("Level", style="dim", width=10)
+
+        for event in events:
+            fields = _extract_event_fields(event)
+            name = str(fields.get("name", fields.get("pipeline_name", "N/A")))
+            status = str(fields.get("status", "N/A"))
+            color = STATUS_COLORS.get(status.lower(), "white")
+            status_styled = f"[{color}]{status}[/{color}]"
+
+            duration_raw = fields.get("duration", None)
+            if duration_raw is not None:
+                duration_ms = duration_raw / 1_000_000
+                if duration_ms >= 1000:
+                    duration_str = f"{duration_ms / 1000:.1f}s"
+                else:
+                    duration_str = f"{duration_ms:.0f}ms"
+            else:
+                duration_str = "N/A"
+
+            level = str(fields.get("level", fields.get("pipeline_level", "N/A")))
+
+            event_id = str(event.id or "N/A")
+            if len(event_id) > 18:
+                event_id = event_id[:16] + ".."
+
+            table.add_row(event_id, name, status_styled, duration_str, level)
+
+        console.print(table)
+        console.print(f"\n[dim]Total events: {len(events)}[/dim]")

--- a/tests/commands/test_ci.py
+++ b/tests/commands/test_ci.py
@@ -1,0 +1,360 @@
+"""Tests for CI Visibility commands."""
+
+import json
+from unittest.mock import Mock, patch
+
+
+def _create_mock_pipeline_event(event_id, name, status, duration_ns=None, branch=None):
+    """Create a mock CI pipeline event."""
+    inner_attrs = {
+        "name": name,
+        "status": status,
+    }
+    if duration_ns is not None:
+        inner_attrs["duration"] = duration_ns
+    if branch is not None:
+        inner_attrs["git"] = {"branch": branch}
+
+    attrs = Mock()
+    attrs.attributes = inner_attrs
+
+    event = Mock()
+    event.id = event_id
+    event.type = "cipipeline"
+    event.attributes = attrs
+    return event
+
+
+def _create_mock_test_event(event_id, name, suite, status, duration_ns=None):
+    """Create a mock CI test event."""
+    inner_attrs = {
+        "name": name,
+        "suite": suite,
+        "status": status,
+    }
+    if duration_ns is not None:
+        inner_attrs["duration"] = duration_ns
+
+    attrs = Mock()
+    attrs.attributes = inner_attrs
+
+    event = Mock()
+    event.id = event_id
+    event.type = "citest"
+    event.attributes = attrs
+    return event
+
+
+# ============================================================================
+# Pipelines command tests
+# ============================================================================
+
+
+def test_pipelines_table(mock_client, runner):
+    """Test pipelines command displays table with correct headers and data."""
+    from ddogctl.commands.ci import ci
+
+    events = [
+        _create_mock_pipeline_event(
+            "evt-001", "deploy-prod", "success", duration_ns=30_000_000_000, branch="main"
+        ),
+        _create_mock_pipeline_event(
+            "evt-002", "run-tests", "failed", duration_ns=120_000_000_000, branch="feature/x"
+        ),
+    ]
+    mock_response = Mock(data=events)
+    mock_client.ci_pipelines.list_ci_app_pipeline_events.return_value = mock_response
+
+    with patch("ddogctl.commands.ci.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(ci, ["pipelines"])
+
+        assert result.exit_code == 0
+        assert "CI Pipeline Events" in result.output
+        assert "deploy-prod" in result.output
+        assert "run-tests" in result.output
+        assert "main" in result.output
+        assert "Total pipeline events: 2" in result.output
+
+
+def test_pipelines_json(mock_client, runner):
+    """Test pipelines command outputs valid JSON with expected fields."""
+    from ddogctl.commands.ci import ci
+
+    events = [
+        _create_mock_pipeline_event(
+            "evt-100", "build-app", "success", duration_ns=5_000_000_000, branch="main"
+        ),
+    ]
+    mock_response = Mock(data=events)
+    mock_client.ci_pipelines.list_ci_app_pipeline_events.return_value = mock_response
+
+    with patch("ddogctl.commands.ci.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(ci, ["pipelines", "--format", "json"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert len(output) == 1
+        assert output[0]["id"] == "evt-100"
+        assert output[0]["name"] == "build-app"
+        assert output[0]["status"] == "success"
+        assert output[0]["duration"] == 5_000_000_000
+
+
+def test_pipelines_empty(mock_client, runner):
+    """Test pipelines command with no results shows total 0."""
+    from ddogctl.commands.ci import ci
+
+    mock_response = Mock(data=[])
+    mock_client.ci_pipelines.list_ci_app_pipeline_events.return_value = mock_response
+
+    with patch("ddogctl.commands.ci.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(ci, ["pipelines"])
+
+        assert result.exit_code == 0
+        assert "Total pipeline events: 0" in result.output
+
+
+def test_pipelines_with_query(mock_client, runner):
+    """Test pipelines command passes query to API."""
+    from ddogctl.commands.ci import ci
+
+    mock_response = Mock(data=[])
+    mock_client.ci_pipelines.list_ci_app_pipeline_events.return_value = mock_response
+
+    with patch("ddogctl.commands.ci.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(ci, ["pipelines", "--query", "@ci.status:error"])
+
+        assert result.exit_code == 0
+        call_kwargs = mock_client.ci_pipelines.list_ci_app_pipeline_events.call_args.kwargs
+        assert call_kwargs["filter_query"] == "@ci.status:error"
+
+
+def test_pipelines_with_limit(mock_client, runner):
+    """Test pipelines command passes limit to API."""
+    from ddogctl.commands.ci import ci
+
+    mock_response = Mock(data=[])
+    mock_client.ci_pipelines.list_ci_app_pipeline_events.return_value = mock_response
+
+    with patch("ddogctl.commands.ci.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(ci, ["pipelines", "--limit", "10"])
+
+        assert result.exit_code == 0
+        call_kwargs = mock_client.ci_pipelines.list_ci_app_pipeline_events.call_args.kwargs
+        assert call_kwargs["page_limit"] == 10
+
+
+def test_pipelines_duration_formatting(mock_client, runner):
+    """Test that pipeline durations are formatted correctly in table."""
+    from ddogctl.commands.ci import ci
+
+    events = [
+        # 30 seconds -> should display as "30.0s"
+        _create_mock_pipeline_event("evt-1", "fast-job", "success", duration_ns=30_000_000_000),
+        # 500 milliseconds -> should display as "500ms"
+        _create_mock_pipeline_event("evt-2", "quick-job", "success", duration_ns=500_000_000),
+    ]
+    mock_response = Mock(data=events)
+    mock_client.ci_pipelines.list_ci_app_pipeline_events.return_value = mock_response
+
+    with patch("ddogctl.commands.ci.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(ci, ["pipelines"])
+
+        assert result.exit_code == 0
+        assert "30.0s" in result.output
+        assert "500ms" in result.output
+
+
+# ============================================================================
+# Tests command tests
+# ============================================================================
+
+
+def test_tests_table(mock_client, runner):
+    """Test tests command displays table with correct headers and data."""
+    from ddogctl.commands.ci import ci
+
+    events = [
+        _create_mock_test_event(
+            "test-001", "test_login", "unit-tests", "pass", duration_ns=250_000_000
+        ),
+        _create_mock_test_event(
+            "test-002", "test_checkout", "integration", "fail", duration_ns=1_500_000_000
+        ),
+    ]
+    mock_response = Mock(data=events)
+    mock_client.ci_tests.list_ci_app_test_events.return_value = mock_response
+
+    with patch("ddogctl.commands.ci.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(ci, ["tests"])
+
+        assert result.exit_code == 0
+        assert "CI Test Events" in result.output
+        assert "test_login" in result.output
+        assert "test_checkout" in result.output
+        assert "unit-tests" in result.output
+        assert "integration" in result.output
+        assert "Total test events: 2" in result.output
+
+
+def test_tests_json(mock_client, runner):
+    """Test tests command outputs valid JSON with expected fields."""
+    from ddogctl.commands.ci import ci
+
+    events = [
+        _create_mock_test_event(
+            "test-200", "test_signup", "auth-suite", "pass", duration_ns=100_000_000
+        ),
+    ]
+    mock_response = Mock(data=events)
+    mock_client.ci_tests.list_ci_app_test_events.return_value = mock_response
+
+    with patch("ddogctl.commands.ci.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(ci, ["tests", "--format", "json"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert len(output) == 1
+        assert output[0]["id"] == "test-200"
+        assert output[0]["name"] == "test_signup"
+        assert output[0]["suite"] == "auth-suite"
+        assert output[0]["status"] == "pass"
+
+
+def test_tests_with_query(mock_client, runner):
+    """Test tests command passes query to API."""
+    from ddogctl.commands.ci import ci
+
+    mock_response = Mock(data=[])
+    mock_client.ci_tests.list_ci_app_test_events.return_value = mock_response
+
+    with patch("ddogctl.commands.ci.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(ci, ["tests", "--query", "@test.status:fail"])
+
+        assert result.exit_code == 0
+        call_kwargs = mock_client.ci_tests.list_ci_app_test_events.call_args.kwargs
+        assert call_kwargs["filter_query"] == "@test.status:fail"
+
+
+def test_tests_empty(mock_client, runner):
+    """Test tests command with no results shows total 0."""
+    from ddogctl.commands.ci import ci
+
+    mock_response = Mock(data=[])
+    mock_client.ci_tests.list_ci_app_test_events.return_value = mock_response
+
+    with patch("ddogctl.commands.ci.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(ci, ["tests"])
+
+        assert result.exit_code == 0
+        assert "Total test events: 0" in result.output
+
+
+def test_tests_with_limit(mock_client, runner):
+    """Test tests command passes limit to API."""
+    from ddogctl.commands.ci import ci
+
+    mock_response = Mock(data=[])
+    mock_client.ci_tests.list_ci_app_test_events.return_value = mock_response
+
+    with patch("ddogctl.commands.ci.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(ci, ["tests", "--limit", "25"])
+
+        assert result.exit_code == 0
+        call_kwargs = mock_client.ci_tests.list_ci_app_test_events.call_args.kwargs
+        assert call_kwargs["page_limit"] == 25
+
+
+# ============================================================================
+# Pipeline details command tests
+# ============================================================================
+
+
+def test_pipeline_details_table(mock_client, runner):
+    """Test pipeline-details command displays table with event details."""
+    from ddogctl.commands.ci import ci
+
+    inner_attrs = {
+        "name": "deploy-prod",
+        "status": "success",
+        "duration": 45_000_000_000,
+        "level": "pipeline",
+    }
+    attrs = Mock()
+    attrs.attributes = inner_attrs
+    event = Mock()
+    event.id = "evt-detail-1"
+    event.type = "cipipeline"
+    event.attributes = attrs
+
+    mock_response = Mock(data=[event])
+    mock_client.ci_pipelines.list_ci_app_pipeline_events.return_value = mock_response
+
+    with patch("ddogctl.commands.ci.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(ci, ["pipeline-details", "pipeline-abc-123"])
+
+        assert result.exit_code == 0
+        assert "pipeline-abc-123" in result.output
+        assert "deploy-prod" in result.output
+        assert "pipeline" in result.output
+        assert "Total events:" in result.output
+
+
+def test_pipeline_details_json(mock_client, runner):
+    """Test pipeline-details command outputs valid JSON."""
+    from ddogctl.commands.ci import ci
+
+    inner_attrs = {
+        "name": "build-app",
+        "status": "success",
+        "duration": 10_000_000_000,
+        "level": "pipeline",
+    }
+    attrs = Mock()
+    attrs.attributes = inner_attrs
+    event = Mock()
+    event.id = "evt-json-1"
+    event.type = "cipipeline"
+    event.attributes = attrs
+
+    mock_response = Mock(data=[event])
+    mock_client.ci_pipelines.list_ci_app_pipeline_events.return_value = mock_response
+
+    with patch("ddogctl.commands.ci.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(ci, ["pipeline-details", "pipe-xyz", "--format", "json"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert len(output) == 1
+        assert output[0]["id"] == "evt-json-1"
+        assert output[0]["name"] == "build-app"
+        assert output[0]["status"] == "success"
+
+
+def test_pipeline_details_not_found(mock_client, runner):
+    """Test pipeline-details with no matching events shows message."""
+    from ddogctl.commands.ci import ci
+
+    mock_response = Mock(data=[])
+    mock_client.ci_pipelines.list_ci_app_pipeline_events.return_value = mock_response
+
+    with patch("ddogctl.commands.ci.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(ci, ["pipeline-details", "nonexistent-pipe"])
+
+        assert result.exit_code == 0
+        assert "No events found" in result.output
+
+
+def test_pipeline_details_query_format(mock_client, runner):
+    """Test pipeline-details searches with correct query filter."""
+    from ddogctl.commands.ci import ci
+
+    mock_response = Mock(data=[])
+    mock_client.ci_pipelines.list_ci_app_pipeline_events.return_value = mock_response
+
+    with patch("ddogctl.commands.ci.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(ci, ["pipeline-details", "my-pipeline-id"])
+
+        assert result.exit_code == 0
+        call_kwargs = mock_client.ci_pipelines.list_ci_app_pipeline_events.call_args.kwargs
+        assert "@ci.pipeline.id:my-pipeline-id" in call_kwargs["filter_query"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,8 @@ def mock_client():
     client.usage = Mock()
     client.synthetics = Mock()
     client.rum = Mock()
+    client.ci_pipelines = Mock()
+    client.ci_tests = Mock()
     return client
 
 


### PR DESCRIPTION
## Summary
- Add `ddogctl ci` command group with `pipelines`, `tests`, and `pipeline-details` subcommands
- Integrate `CIVisibilityPipelinesApi` and `CIVisibilityTestsApi` (v2) into the Datadog client
- Support rich table and JSON output formats with duration formatting and status color-coding

## Test plan
- [x] Unit tests for all 3 subcommands (15 tests total)
- [x] Search query parameter passing verified
- [x] Empty results handling verified
- [x] Duration formatting (ms/s) verified
- [x] Full test suite passes (601 tests)
- [x] black and ruff checks pass