### PR TITLE
feat(notebook): add notebook management commands

### DIFF
--- a/ddogctl/cli.py
+++ b/ddogctl/cli.py
@@ -81,6 +81,7 @@ from ddogctl.commands.slo import slo
 from ddogctl.commands.dashboard import dashboard
 from ddogctl.commands.synthetics import synthetics
 from ddogctl.commands.rum import rum
+from ddogctl.commands.notebook import notebook
 from ddogctl.commands.completion import completion
 from ddogctl.commands.apply import apply_cmd, diff_cmd
 from ddogctl.commands.config import config
@@ -104,6 +105,7 @@ main.add_command(slo)
 main.add_command(dashboard)
 main.add_command(synthetics)
 main.add_command(rum)
+main.add_command(notebook)
 main.add_command(completion)
 main.add_command(apply_cmd)
 main.add_command(diff_cmd)

--- a/ddogctl/client.py
+++ b/ddogctl/client.py
@@ -14,6 +14,7 @@ from datadog_api_client.v1.api import (
     dashboards_api,
     usage_metering_api,
     synthetics_api,
+    notebooks_api,
 )
 from datadog_api_client.v2.api import (
     logs_api,
@@ -55,6 +56,7 @@ class DatadogClient:
         self.dashboards = dashboards_api.DashboardsApi(self.api_client)
         self.usage = usage_metering_api.UsageMeteringApi(self.api_client)
         self.synthetics = synthetics_api.SyntheticsApi(self.api_client)
+        self.notebooks = notebooks_api.NotebooksApi(self.api_client)
 
         # V2 APIs
         self.logs = logs_api.LogsApi(self.api_client)

--- a/ddogctl/commands/notebook.py
+++ b/ddogctl/commands/notebook.py
@@ -1,0 +1,223 @@
+"""Notebook management commands."""
+
+import click
+import json
+from rich.console import Console
+from rich.table import Table
+from ddogctl.client import get_datadog_client
+from ddogctl.utils.error import handle_api_error
+from ddogctl.utils.confirm import confirm_action
+
+console = Console()
+
+
+@click.group()
+def notebook():
+    """Notebook management commands."""
+    pass
+
+
+@notebook.command(name="list")
+@click.option(
+    "--format", type=click.Choice(["json", "table"]), default="table", help="Output format"
+)
+@handle_api_error
+def list_notebooks(format):
+    """List all notebooks."""
+    client = get_datadog_client()
+
+    with console.status("[cyan]Fetching notebooks...[/cyan]"):
+        response = client.notebooks.list_notebooks()
+
+    notebooks_list = response.data or []
+
+    if format == "json":
+        output = []
+        for nb in notebooks_list:
+            attrs = nb.attributes
+            output.append(
+                {
+                    "id": nb.id,
+                    "name": getattr(attrs, "name", ""),
+                    "author": (
+                        getattr(attrs, "author", {}).get("handle", "")
+                        if isinstance(getattr(attrs, "author", None), dict)
+                        else str(getattr(attrs, "author", ""))
+                    ),
+                    "modified": str(getattr(attrs, "modified", "")),
+                    "status": str(getattr(attrs, "status", "")),
+                }
+            )
+        print(json.dumps(output, indent=2, default=str))
+    else:
+        table = Table(title="Notebooks", show_lines=False)
+        table.add_column("ID", style="cyan", no_wrap=True)
+        table.add_column("Name", style="white", min_width=30)
+        table.add_column("Author", style="dim")
+        table.add_column("Modified", style="dim")
+        table.add_column("Status", style="yellow")
+
+        for nb in notebooks_list:
+            attrs = nb.attributes
+            author = getattr(attrs, "author", None)
+            if isinstance(author, dict):
+                author_str = author.get("handle", "")
+            else:
+                author_str = str(author) if author else ""
+
+            table.add_row(
+                str(nb.id),
+                str(getattr(attrs, "name", "")),
+                author_str,
+                str(getattr(attrs, "modified", "")),
+                str(getattr(attrs, "status", "")),
+            )
+
+        console.print(table)
+        console.print(f"\n[dim]Total notebooks: {len(notebooks_list)}[/dim]")
+
+
+@notebook.command(name="get")
+@click.argument("notebook_id", type=int)
+@click.option(
+    "--format", type=click.Choice(["json", "table"]), default="table", help="Output format"
+)
+@handle_api_error
+def get_notebook(notebook_id, format):
+    """Get notebook details."""
+    client = get_datadog_client()
+
+    with console.status(f"[cyan]Fetching notebook {notebook_id}...[/cyan]"):
+        response = client.notebooks.get_notebook(notebook_id=notebook_id)
+
+    nb = response.data
+    attrs = nb.attributes
+
+    if format == "json":
+        output = {
+            "id": nb.id,
+            "name": getattr(attrs, "name", ""),
+            "author": (
+                getattr(attrs, "author", {}).get("handle", "")
+                if isinstance(getattr(attrs, "author", None), dict)
+                else str(getattr(attrs, "author", ""))
+            ),
+            "cells": len(getattr(attrs, "cells", []) or []),
+            "created": str(getattr(attrs, "created", "")),
+            "modified": str(getattr(attrs, "modified", "")),
+            "status": str(getattr(attrs, "status", "")),
+        }
+        print(json.dumps(output, indent=2, default=str))
+    else:
+        console.print(f"\n[bold cyan]Notebook {nb.id}[/bold cyan]")
+        console.print(f"[bold]Name:[/bold] {getattr(attrs, 'name', '')}")
+
+        author = getattr(attrs, "author", None)
+        if author:
+            author_str = author.get("handle", "") if isinstance(author, dict) else str(author)
+            console.print(f"[bold]Author:[/bold] {author_str}")
+
+        created = getattr(attrs, "created", None)
+        if created:
+            console.print(f"[bold]Created:[/bold] {created}")
+
+        modified = getattr(attrs, "modified", None)
+        if modified:
+            console.print(f"[bold]Modified:[/bold] {modified}")
+
+        status = getattr(attrs, "status", None)
+        if status:
+            console.print(f"[bold]Status:[/bold] {status}")
+
+        cells = getattr(attrs, "cells", []) or []
+        console.print(f"[bold]Cells:[/bold] {len(cells)}")
+
+
+@notebook.command(name="create")
+@click.option("--name", required=True, help="Notebook name")
+@click.option(
+    "--format", type=click.Choice(["json", "table"]), default="table", help="Output format"
+)
+@handle_api_error
+def create_notebook(name, format):
+    """Create a notebook."""
+    from datadog_api_client.v1.model.notebook_create_request import NotebookCreateRequest
+    from datadog_api_client.v1.model.notebook_create_data import NotebookCreateData
+    from datadog_api_client.v1.model.notebook_create_data_attributes import (
+        NotebookCreateDataAttributes,
+    )
+    from datadog_api_client.v1.model.notebook_cell_create_request import NotebookCellCreateRequest
+    from datadog_api_client.v1.model.notebook_timeseries_cell_attributes import (
+        NotebookTimeseriesCellAttributes,
+    )
+    from datadog_api_client.v1.model.timeseries_widget_definition import (
+        TimeseriesWidgetDefinition,
+    )
+    from datadog_api_client.v1.model.timeseries_widget_definition_type import (
+        TimeseriesWidgetDefinitionType,
+    )
+    from datadog_api_client.v1.model.timeseries_widget_request import TimeseriesWidgetRequest
+    from datadog_api_client.v1.model.notebook_cell_resource_type import NotebookCellResourceType
+    from datadog_api_client.v1.model.notebook_resource_type import NotebookResourceType
+    from datadog_api_client.v1.model.notebook_relative_time import NotebookRelativeTime
+
+    client = get_datadog_client()
+
+    # Build a default timeseries cell
+    cell = NotebookCellCreateRequest(
+        attributes=NotebookTimeseriesCellAttributes(
+            definition=TimeseriesWidgetDefinition(
+                type=TimeseriesWidgetDefinitionType.TIMESERIES,
+                requests=[
+                    TimeseriesWidgetRequest(
+                        q="avg:system.cpu.user{*}",
+                    )
+                ],
+            ),
+        ),
+        type=NotebookCellResourceType.NOTEBOOK_CELLS,
+    )
+
+    body = NotebookCreateRequest(
+        data=NotebookCreateData(
+            attributes=NotebookCreateDataAttributes(
+                cells=[cell],
+                name=name,
+                time=NotebookRelativeTime(live_span="1h"),
+            ),
+            type=NotebookResourceType.NOTEBOOKS,
+        ),
+    )
+
+    with console.status("[cyan]Creating notebook...[/cyan]"):
+        response = client.notebooks.create_notebook(body=body)
+
+    nb = response.data
+
+    if format == "json":
+        output = {
+            "id": nb.id,
+            "name": getattr(nb.attributes, "name", ""),
+        }
+        print(json.dumps(output, indent=2, default=str))
+    else:
+        console.print(f"[green]Notebook {nb.id} created[/green]")
+        console.print(f"[bold]Name:[/bold] {getattr(nb.attributes, 'name', '')}")
+
+
+@notebook.command(name="delete")
+@click.argument("notebook_id", type=int)
+@click.option("--confirm", "confirmed", is_flag=True, help="Skip confirmation prompt")
+@handle_api_error
+def delete_notebook(notebook_id, confirmed):
+    """Delete a notebook by ID."""
+    if not confirm_action(f"Delete notebook {notebook_id}?", confirmed):
+        console.print("[yellow]Aborted[/yellow]")
+        return
+
+    client = get_datadog_client()
+
+    with console.status(f"[cyan]Deleting notebook {notebook_id}...[/cyan]"):
+        client.notebooks.delete_notebook(notebook_id=notebook_id)
+
+    console.print(f"[green]Notebook {notebook_id} deleted[/green]")

--- a/tests/commands/test_notebook.py
+++ b/tests/commands/test_notebook.py
@@ -1,0 +1,272 @@
+"""Tests for notebook commands."""
+
+import json
+import pytest
+from unittest.mock import Mock, patch
+from click.testing import CliRunner
+from ddogctl.commands.notebook import notebook
+
+
+class TestListNotebooks:
+    """Tests for notebook list command."""
+
+    @pytest.fixture
+    def mock_client(self):
+        client = Mock()
+        client.notebooks = Mock()
+        return client
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def _make_notebook(
+        self, id, name, author="user@example.com", modified="2025-01-15", status="published"
+    ):
+        """Create a mock notebook data item."""
+        attrs = Mock()
+        attrs.name = name
+        attrs.author = {"handle": author}
+        attrs.cells = [Mock(), Mock()]
+        attrs.created = "2025-01-01"
+        attrs.modified = modified
+        attrs.status = status
+
+        nb = Mock()
+        nb.id = id
+        nb.type = "notebooks"
+        nb.attributes = attrs
+        return nb
+
+    def test_list_notebooks_table(self, mock_client, runner):
+        """Test listing notebooks in table format."""
+        nb1 = self._make_notebook(1, "Investigation Notebook", modified="2025-01-15")
+        nb2 = self._make_notebook(
+            2, "Performance Analysis", author="admin@example.com", modified="2025-01-20"
+        )
+
+        response = Mock()
+        response.data = [nb1, nb2]
+        mock_client.notebooks.list_notebooks.return_value = response
+
+        with patch("ddogctl.commands.notebook.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(notebook, ["list"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Investigation Notebook" in result.output
+        assert "Performance Analysis" in result.output
+        assert "Total notebooks: 2" in result.output
+
+    def test_list_notebooks_json(self, mock_client, runner):
+        """Test listing notebooks in JSON format."""
+        nb1 = self._make_notebook(1, "Investigation Notebook")
+
+        response = Mock()
+        response.data = [nb1]
+        mock_client.notebooks.list_notebooks.return_value = response
+
+        with patch("ddogctl.commands.notebook.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(notebook, ["list", "--format", "json"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert len(output) == 1
+        assert output[0]["id"] == 1
+        assert output[0]["name"] == "Investigation Notebook"
+        assert output[0]["author"] == "user@example.com"
+
+    def test_list_notebooks_empty(self, mock_client, runner):
+        """Test listing notebooks when none exist."""
+        response = Mock()
+        response.data = []
+        mock_client.notebooks.list_notebooks.return_value = response
+
+        with patch("ddogctl.commands.notebook.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(notebook, ["list"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Total notebooks: 0" in result.output
+
+
+class TestGetNotebook:
+    """Tests for notebook get command."""
+
+    @pytest.fixture
+    def mock_client(self):
+        client = Mock()
+        client.notebooks = Mock()
+        return client
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def _make_notebook_detail(
+        self,
+        id=1,
+        name="Test Notebook",
+        author="user@example.com",
+        cells=None,
+        created="2025-01-01",
+        modified="2025-01-15",
+        status="published",
+    ):
+        """Create a mock notebook response for get."""
+        attrs = Mock()
+        attrs.name = name
+        attrs.author = {"handle": author}
+        attrs.cells = cells or [Mock(), Mock(), Mock()]
+        attrs.created = created
+        attrs.modified = modified
+        attrs.status = status
+
+        nb = Mock()
+        nb.id = id
+        nb.type = "notebooks"
+        nb.attributes = attrs
+
+        response = Mock()
+        response.data = nb
+        return response
+
+    def test_get_notebook_table(self, mock_client, runner):
+        """Test getting notebook details in table format."""
+        response = self._make_notebook_detail(
+            id=42, name="Latency Investigation", author="ops@example.com"
+        )
+        mock_client.notebooks.get_notebook.return_value = response
+
+        with patch("ddogctl.commands.notebook.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(notebook, ["get", "42"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Notebook 42" in result.output
+        assert "Latency Investigation" in result.output
+        assert "ops@example.com" in result.output
+        assert "Cells:" in result.output
+        mock_client.notebooks.get_notebook.assert_called_once_with(notebook_id=42)
+
+    def test_get_notebook_json(self, mock_client, runner):
+        """Test getting notebook details in JSON format."""
+        response = self._make_notebook_detail(id=42, name="Latency Investigation")
+        mock_client.notebooks.get_notebook.return_value = response
+
+        with patch("ddogctl.commands.notebook.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(notebook, ["get", "42", "--format", "json"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["id"] == 42
+        assert output["name"] == "Latency Investigation"
+        assert output["cells"] == 3
+
+
+class TestCreateNotebook:
+    """Tests for notebook create command."""
+
+    @pytest.fixture
+    def mock_client(self):
+        client = Mock()
+        client.notebooks = Mock()
+        return client
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def test_create_notebook(self, mock_client, runner):
+        """Test creating a notebook."""
+        nb_attrs = Mock()
+        nb_attrs.name = "New Notebook"
+
+        nb = Mock()
+        nb.id = 99
+        nb.attributes = nb_attrs
+
+        response = Mock()
+        response.data = nb
+        mock_client.notebooks.create_notebook.return_value = response
+
+        with patch("ddogctl.commands.notebook.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(notebook, ["create", "--name", "New Notebook"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Notebook 99 created" in result.output
+        assert "New Notebook" in result.output
+        mock_client.notebooks.create_notebook.assert_called_once()
+
+    def test_create_notebook_json(self, mock_client, runner):
+        """Test creating a notebook with JSON output."""
+        nb_attrs = Mock()
+        nb_attrs.name = "New Notebook"
+
+        nb = Mock()
+        nb.id = 99
+        nb.attributes = nb_attrs
+
+        response = Mock()
+        response.data = nb
+        mock_client.notebooks.create_notebook.return_value = response
+
+        with patch("ddogctl.commands.notebook.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                notebook, ["create", "--name", "New Notebook", "--format", "json"]
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["id"] == 99
+        assert output["name"] == "New Notebook"
+
+    def test_create_notebook_requires_name(self, mock_client, runner):
+        """Test that --name is required."""
+        with patch("ddogctl.commands.notebook.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(notebook, ["create"])
+
+        assert result.exit_code != 0
+        assert "Missing option" in result.output or "required" in result.output.lower()
+
+
+class TestDeleteNotebook:
+    """Tests for notebook delete command."""
+
+    @pytest.fixture
+    def mock_client(self):
+        client = Mock()
+        client.notebooks = Mock()
+        return client
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def test_delete_notebook_with_confirm(self, mock_client, runner):
+        """Test deleting a notebook with --confirm flag (no prompt)."""
+        mock_client.notebooks.delete_notebook.return_value = None
+
+        with patch("ddogctl.commands.notebook.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(notebook, ["delete", "42", "--confirm"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Notebook 42 deleted" in result.output
+        mock_client.notebooks.delete_notebook.assert_called_once_with(notebook_id=42)
+
+    def test_delete_notebook_interactive_yes(self, mock_client, runner):
+        """Test deleting a notebook with interactive confirmation (user says yes)."""
+        mock_client.notebooks.delete_notebook.return_value = None
+
+        with patch("ddogctl.commands.notebook.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(notebook, ["delete", "42"], input="y\n")
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Notebook 42 deleted" in result.output
+        mock_client.notebooks.delete_notebook.assert_called_once_with(notebook_id=42)
+
+    def test_delete_notebook_without_confirm(self, mock_client, runner):
+        """Test deleting a notebook with interactive confirmation (user says no)."""
+        with patch("ddogctl.commands.notebook.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(notebook, ["delete", "42"], input="n\n")
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "Aborted" in result.output
+        mock_client.notebooks.delete_notebook.assert_not_called()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ def mock_client():
     client.rum = Mock()
     client.ci_pipelines = Mock()
     client.ci_tests = Mock()
+    client.notebooks = Mock()
     return client
 
 


### PR DESCRIPTION
## Summary
- Add `ddogctl notebook` command group with list, get, create, delete subcommands
- Support for investigation notebooks via NotebooksApi (v1)
- Rich table and JSON output formats

## Test plan
- [x] Unit tests for all subcommands (11 tests)
- [x] CRUD operations tested
- [x] Delete confirmation tested (--confirm flag, interactive yes, interactive no)
- [x] pytest passes (597 tests)
- [x] black formatting passes
- [x] ruff lint passes