### PR TITLE
docs: update CLAUDE.md to reflect completed roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-ddogctl is a modern CLI for the Datadog API. Like Dogshell, but better. Rich terminal output, APM/logs/DBM support, retry logic, investigation workflows. Requires Python 3.10+.
+ddogctl is a modern CLI for the Datadog API. Like Dogshell, but better. Rich terminal output, 22 command groups, retry logic, structured JSON output, stdin piping, and investigation workflows. Requires Python 3.10+.
 
 ## Commands
 
@@ -34,35 +34,60 @@ uv run ddogctl investigate latency my-service --threshold 500
 
 ## Architecture
 
-**Entry point**: `ddogctl.cli:main` — a Click group that registers command subgroups.
+**Entry point**: `ddogctl.cli:main` — a Click group (`AliasGroup`) that registers command subgroups.
 
-**Command structure** (`ddogctl/commands/`): Each file defines a Click group with subcommands. Commands call `get_datadog_client()` to get an API client, then use Rich for output formatting.
+**Command groups** (`ddogctl/commands/`): Each file defines a Click group with subcommands. Commands call `get_datadog_client()` to get an API client, then use Rich for output formatting. All commands support `--format json|table`.
 
 ```
-ddogctl monitor {list, get, mute, unmute, validate}
-ddogctl metric  {query, search, metadata}
-ddogctl event   {list, get, post}
-ddogctl host    {list, get, totals}
-ddogctl apm     {services, traces, analytics}
-ddogctl logs    {search, tail, query, trace}
-ddogctl dbm     {hosts, queries, explain, samples}
-ddogctl investigate {latency, errors, throughput, compare}
+ddogctl monitor      {list, get, create, update, delete, mute, unmute, validate, mute-all, unmute-all}
+ddogctl metric       {query, search, metadata}
+ddogctl event        {list, get, post}
+ddogctl host         {list, get, totals}
+ddogctl apm          {services, traces, analytics}
+ddogctl logs         {search, tail, query, trace}
+ddogctl dbm          {hosts, queries, explain, samples}
+ddogctl investigate  {latency, errors, throughput, compare}
+ddogctl dashboard    {list, get, create, update, delete, export, clone}
+ddogctl slo          {list, get, create, update, delete, history, export}
+ddogctl downtime     {list, get, create, update, delete, cancel-by-scope}
+ddogctl tag          {list, add, replace, detach}
+ddogctl service-check {post}
+ddogctl synthetics   {list, get, results, trigger}
+ddogctl incident     {list, get, create, update, delete}
+ddogctl notebook     {list, get, create, delete}
+ddogctl user         {list, get, invite, disable}
+ddogctl usage        {summary, hosts, logs, top-avg-metrics}
+ddogctl rum          {events, analytics}
+ddogctl ci           {pipelines, tests, pipeline-details}
+ddogctl config       {init, set-profile, use-profile, list-profiles, get}
+ddogctl apply        -f <file> [--dry-run] [--recursive]
+ddogctl diff         -f <file>
+ddogctl completion   {bash, zsh, fish}
 ```
+
+**Aliases**: `mon`=monitor, `dash`=dashboard, `dt`=downtime, `sc`=service-check, `inv`=investigate
 
 **Key modules**:
-- `ddogctl/client.py` — `DatadogClient` wraps `datadog_api_client` SDK, exposing V1 APIs (monitors, metrics, events, hosts, tags) and V2 APIs (logs, spans). Use `get_datadog_client()` to instantiate.
-- `ddogctl/config.py` — `DatadogConfig` (Pydantic BaseSettings) loads from env vars (`DD_API_KEY`, `DD_APP_KEY`, `DD_SITE`). Supports region shortcuts (us, eu, us3, us5, ap1, gov).
-- `ddogctl/utils/error.py` — `@handle_api_error` decorator with retry logic (exponential backoff on 429/5xx, immediate exit on 401/403).
+- `ddogctl/client.py` — `DatadogClient` wraps `datadog_api_client` SDK. V1 APIs: monitors, metrics, events, hosts, tags, service_checks, downtimes, slos, dashboards, usage, synthetics, notebooks. V2 APIs: logs, spans, service_definitions, incidents, users, rum, ci_pipelines, ci_tests. Use `get_datadog_client()` to instantiate.
+- `ddogctl/config.py` — `DatadogConfig` (Pydantic BaseSettings) loads from env vars (`DD_API_KEY`, `DD_APP_KEY`, `DD_SITE`) or `~/.ddogctl/config.json` profiles. Supports region shortcuts (us, eu, us3, us5, ap1, gov). Precedence: CLI `--profile` flag > env var > active profile > defaults.
+- `ddogctl/utils/error.py` — `@handle_api_error` decorator with retry logic (exponential backoff on 429/5xx, immediate exit on 401/403). Emits structured JSON errors when `--format json`.
+- `ddogctl/utils/exit_codes.py` — Semantic exit codes: 0=success, 1=general, 2=auth, 3=not found, 4=validation, 5=rate limited, 6=server error.
 - `ddogctl/utils/time.py` — `parse_time_range()` handles relative (1h, 24h, 7d) and ISO datetime formats, returns Unix timestamps.
+- `ddogctl/utils/confirm.py` — `--confirm` flag utility for destructive operations.
+- `ddogctl/utils/file_input.py` — `-f`/`--file` JSON input parsing.
+- `ddogctl/utils/export.py` — JSON export to file.
+- `ddogctl/utils/stdin.py` — `--from-stdin` flag for composable piping.
+- `ddogctl/utils/watch.py` — `--watch` mode with Rich Live display.
+- `ddogctl/utils/output.py` — Structured error output helpers.
 - `ddogctl/utils/tags.py` — Tag parsing and display formatting.
-- `ddogctl/utils/spans.py` — `aggregate_spans()` wrapper for spans API aggregation (used by APM analytics and investigate commands).
+- `ddogctl/utils/spans.py` — `aggregate_spans()` wrapper for spans API aggregation.
 
 ## Testing Patterns
 
 Tests use `unittest.mock` with Click's `CliRunner`. Key fixtures from `tests/conftest.py`:
-- `mock_client` — Mock with `.monitors`, `.hosts`, `.metrics`, `.events`, `.spans`, `.logs`, `.dbm` attributes
+- `mock_client` — Mock with all API attributes (`.monitors`, `.hosts`, `.metrics`, `.events`, `.spans`, `.logs`, `.dbm`, `.service_definitions`, `.service_checks`, `.downtimes`, `.slos`, `.dashboards`, `.incidents`, `.users`, `.usage`, `.synthetics`, `.rum`, `.ci_pipelines`, `.ci_tests`, `.notebooks`)
 - `runner` — `CliRunner()` instance
-- Factory functions: `create_mock_monitor()`, `create_mock_host()`, `create_mock_span()`, `create_mock_log()`, `create_mock_dbm_host()`, `create_mock_dbm_query()`, `create_mock_dbm_sample()`
+- Factory functions: `create_mock_monitor()`, `create_mock_host()`, `create_mock_span()`, `create_mock_log()`, `create_mock_dbm_host()`, `create_mock_dbm_query()`, `create_mock_dbm_sample()`, `create_mock_service_list()`, `create_mock_rum_event()`
 
 Standard test pattern: patch `get_datadog_client` to return `mock_client`, invoke command via `runner`, assert on output and exit code.
 
@@ -71,15 +96,15 @@ Standard test pattern: patch `get_datadog_client` to return `mock_client`, invok
 - **Worktrees**: Always create a Git worktree for every new feature, fix, or change. Use the `./.worktrees` folder. Use `git gtr` instead of plain `git worktree` commands.
 - **Pull requests**: Every change lands via PR — no direct commits to `main`. Open a PR from the worktree branch, get it reviewed, then merge.
 - **Commits**: Follow conventional commit format.
+- **CI**: Tests run on Python 3.10-3.13 + `claude-review` AI code review. Never merge without all CI checks passing.
 
 ## Development Methodology
 
 Strict TDD (RED-GREEN-REFACTOR). Coverage target >90%. Reference implementation: `ddogctl/commands/apm.py`.
 
-## Roadmap
+## Gotchas
 
-See `docs/plans/2026-02-12-ddogctl-roadmap-design.md` for the approved 4-phase plan:
-- **Phase 1**: API parity with Dogshell (monitor CRUD, dashboards, SLOs, downtimes, tags, service checks)
-- **Phase 2**: CLI UX (profiles, apply/diff, shell completion, watch mode)
-- **Phase 3**: Agentic (structured errors, semantic exit codes, stdin piping)
-- **Phase 4**: Beyond Dogshell (synthetics, incidents, notebooks, users, usage, RUM, CI)
+- `uv sync` without `--all-extras` will miss dev dependencies (black, ruff, mypy, pytest).
+- When parallel PRs modify `cli.py`, `client.py`, and `conftest.py` (shared files), merge sequentially and rebase each subsequent PR.
+- `git gtr` may not be available everywhere — falls back to `git worktree` commands.
+- The `claude-review` CI check can take 5-17 minutes. Wait for it before merging.


### PR DESCRIPTION
## Summary
- Update CLAUDE.md to reflect all 4 completed roadmap phases
- Add all 22 command groups with their subcommands to architecture section
- Update client.py description with all V1/V2 APIs (12 V1 + 8 V2)
- Update mock_client fixture description with all 21 attributes
- Add 7 new utility modules to key modules section
- Add command aliases documentation
- Add gotchas section with development learnings
- Remove stale roadmap "see plan" reference

## Test plan
- [ ] CLAUDE.md renders correctly in GitHub
- [ ] All documented commands match actual codebase