### PR TITLE
chore: bump version to 2.0.0

### DIFF
--- a/ddogctl/cli.py
+++ b/ddogctl/cli.py
@@ -36,7 +36,7 @@ class AliasGroup(click.Group):
 
 
 @click.group(cls=AliasGroup)
-@click.version_option(version="1.0.0")
+@click.version_option(version="2.0.0")
 @click.option(
     "--profile",
     default=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ddogctl"
-version = "1.0.0"
+version = "2.0.0"
 description = "A modern CLI for the Datadog API. Like Dogshell, but better."
 authors = [{name = "Sergio Francisco", email = "email@sergiofrancisco.com"}]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version from 1.0.0 to 2.0.0 in `pyproject.toml` and `cli.py`
- Reflects completion of all 4 roadmap phases (22 command groups, 673 tests)

## Test plan
- [x] All 673 tests pass
- [ ] CI passes
- [ ] After merge, tag `v2.0.0` triggers PyPI publish