### PR TITLE
chore: bump version to 2.0.1

### DIFF
--- a/ddogctl/cli.py
+++ b/ddogctl/cli.py
@@ -36,7 +36,7 @@ class AliasGroup(click.Group):
 
 
 @click.group(cls=AliasGroup)
-@click.version_option(version="2.0.0")
+@click.version_option(version="2.0.1")
 @click.option(
     "--profile",
     default=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ddogctl"
-version = "2.0.0"
+version = "2.0.1"
 description = "A modern CLI for the Datadog API. Like Dogshell, but better."
 authors = [{name = "Sergio Francisco", email = "email@sergiofrancisco.com"}]
 license = "MIT"


### PR DESCRIPTION
Bump version to 2.0.1 for bug fix release.

Changes:
- Update version in pyproject.toml
- Update version in ddogctl/cli.py

This release includes:
- Fix for logs attribute handling with AWS Firelens and other log sources (#36)