### PR TITLE
ci: add PyPI publish workflow for automated releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for PyPI trusted publishing
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Adds GitHub Actions workflow for automated PyPI publishing on version tags.

The workflow:
- Triggers on tags matching `v*`
- Uses PyPI trusted publishing (OIDC)
- Builds with uv
- Publishes to PyPI automatically

**Note**: PyPI trusted publishing must be configured in the PyPI project settings for this to work.