### PR TITLE
chore: bump version to 2.0.2

### DIFF
--- a/ddogctl/cli.py
+++ b/ddogctl/cli.py
@@ -36,7 +36,7 @@ class AliasGroup(click.Group):
 
 
 @click.group(cls=AliasGroup)
-@click.version_option(version="2.0.1")
+@click.version_option(version="2.0.2")
 @click.option(
     "--profile",
     default=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ddogctl"
-version = "2.0.1"
+version = "2.0.2"
 description = "A modern CLI for the Datadog API. Like Dogshell, but better."
 authors = [{name = "Sergio Francisco", email = "email@sergiofrancisco.com"}]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 2.0.2 in `pyproject.toml` and `ddogctl/cli.py`

## Changes since v2.0.1
- fix: remove all work-specific references from codebase (#42)
- fix(logs): include nested attributes in JSON output (#41)
- docs: update CLAUDE.md with session learnings (#39)

## Post-merge
After merging, tag and push:
```bash
git tag -a v2.0.2 -m "v2.0.2"
git push origin v2.0.2
```
This triggers the PyPI publish workflow.