### PR TITLE
fix: resolve multiple CLI errors during incident investigation

### DIFF
--- a/ddogctl/cli.py
+++ b/ddogctl/cli.py
@@ -36,7 +36,7 @@ class AliasGroup(click.Group):
 
 
 @click.group(cls=AliasGroup)
-@click.version_option(version="2.0.2")
+@click.version_option(version="2.0.3")
 @click.option(
     "--profile",
     default=None,

--- a/ddogctl/client.py
+++ b/ddogctl/client.py
@@ -29,6 +29,58 @@ from datadog_api_client.v2.api import (
 from ddogctl.config import DatadogConfig
 
 
+class _Namespace:
+    """Simple namespace for attribute access on API response data."""
+
+    def __init__(self, data):
+        for key, value in data.items():
+            setattr(self, key, value)
+
+
+class _Response:
+    """Minimal response wrapper with a .data attribute."""
+
+    def __init__(self, data):
+        self.data = data
+
+
+class DBMClient:
+    """Lightweight wrapper for DBM API endpoints using direct HTTP calls."""
+
+    def __init__(self, api_client):
+        self._api_client = api_client
+
+    def _call(self, method, path, **query_params):
+        """Make a direct REST call through the SDK's ApiClient."""
+        params = {k: v for k, v in query_params.items() if v is not None}
+        response = self._api_client.call_api(
+            method, path, query_params=params, header_params={"Accept": "application/json"}
+        )
+        import json
+
+        body = json.loads(response.response.data) if response.response.data else {}
+        data_raw = body.get("data", [])
+        if isinstance(data_raw, list):
+            return _Response(
+                [_Namespace(item) if isinstance(item, dict) else item for item in data_raw]
+            )
+        elif isinstance(data_raw, dict):
+            return _Response(_Namespace(data_raw))
+        return _Response(data_raw)
+
+    def list_hosts(self, **kwargs):
+        return self._call("GET", "/api/v2/dbm/hosts", **kwargs)
+
+    def list_queries(self, **kwargs):
+        return self._call("GET", "/api/v2/dbm/activity", **kwargs)
+
+    def get_query_plan(self, query_id, **kwargs):
+        return self._call("GET", f"/api/v2/dbm/query/{query_id}/plan", **kwargs)
+
+    def list_query_samples(self, query_id, **kwargs):
+        return self._call("GET", f"/api/v2/dbm/query/{query_id}/samples", **kwargs)
+
+
 class DatadogClient:
     """Unified Datadog API client."""
 
@@ -67,6 +119,9 @@ class DatadogClient:
         self.rum = rum_api.RUMApi(self.api_client)
         self.ci_pipelines = ci_visibility_pipelines_api.CIVisibilityPipelinesApi(self.api_client)
         self.ci_tests = ci_visibility_tests_api.CIVisibilityTestsApi(self.api_client)
+
+        # DBM (direct HTTP — no dedicated SDK module)
+        self.dbm = DBMClient(self.api_client)
 
     def __enter__(self):
         return self

--- a/ddogctl/commands/event.py
+++ b/ddogctl/commands/event.py
@@ -18,7 +18,8 @@ def event():
 
 
 @event.command(name="list")
-@click.option("--since", default="24h", help="Time range (e.g., 1h, 24h, 7d)")
+@click.option("--from", "from_time", default="24h", help="Start time (e.g., 1h, 24h, 7d)")
+@click.option("--to", "to_time", default="now", help="End time")
 @click.option("--sources", help="Event sources (comma-separated, e.g., alert,deploy)")
 @click.option("--priority", type=click.Choice(["normal", "low"]), help="Event priority")
 @click.option("--tags", help="Filter by tags (comma-separated)")
@@ -26,11 +27,11 @@ def event():
     "--format", type=click.Choice(["json", "table"]), default="table", help="Output format"
 )
 @handle_api_error
-def list_events(since, sources, priority, tags, format):
+def list_events(from_time, to_time, sources, priority, tags, format):
     """List events."""
     client = get_datadog_client()
 
-    from_ts, to_ts = parse_time_range(since, "now")
+    from_ts, to_ts = parse_time_range(from_time, to_time)
 
     with console.status("[cyan]Fetching events...[/cyan]"):
         # Build kwargs only with provided parameters
@@ -49,7 +50,7 @@ def list_events(since, sources, priority, tags, format):
         return
 
     if format == "table":
-        table = Table(title=f"Events (last {since})", show_lines=False)
+        table = Table(title=f"Events (last {from_time})", show_lines=False)
         table.add_column("Time", style="cyan", width=20)
         table.add_column("Title", style="white", min_width=30)
         table.add_column("Source", style="dim", width=15)

--- a/ddogctl/commands/metric.py
+++ b/ddogctl/commands/metric.py
@@ -43,7 +43,7 @@ def query_metric(query, from_time, to_time, format):
             for series in result.series:
                 metric_name = series.get("metric", "unknown")
                 for point in series.get("pointlist", []):
-                    timestamp, value = point
+                    timestamp, value = point.value
                     print(f"{timestamp},{metric_name},{value}")
     else:
         # Table format
@@ -59,7 +59,7 @@ def query_metric(query, from_time, to_time, format):
             # Show last 20 points
             points = series.get("pointlist", [])[-20:]
             for point in points:
-                timestamp, value = point
+                timestamp, value = point.value
                 from datetime import datetime
 
                 dt = datetime.fromtimestamp(timestamp / 1000)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ddogctl"
-version = "2.0.2"
+version = "2.0.3"
 description = "A modern CLI for the Datadog API. Like Dogshell, but better."
 authors = [{name = "Sergio Francisco", email = "email@sergiofrancisco.com"}]
 license = "MIT"

--- a/tests/commands/test_event.py
+++ b/tests/commands/test_event.py
@@ -164,7 +164,7 @@ def test_event_list_with_filters(mock_client, runner):
             event,
             [
                 "list",
-                "--since",
+                "--from",
                 "1h",
                 "--sources",
                 "alert,deploy",
@@ -197,12 +197,12 @@ def test_event_list_with_custom_time_range(mock_client, runner):
         with patch("ddogctl.commands.event.parse_time_range") as mock_parse_time:
             mock_parse_time.return_value = (1609459200, 1609545600)
 
-            result = runner.invoke(event, ["list", "--since", "7d"])
+            result = runner.invoke(event, ["list", "--from", "7d", "--to", "1d"])
 
             assert result.exit_code == 0, f"Command failed: {result.output}"
 
-            # Verify parse_time_range was called
-            mock_parse_time.assert_called_once_with("7d", "now")
+            # Verify parse_time_range was called with both args
+            mock_parse_time.assert_called_once_with("7d", "1d")
 
             # Verify list_events was called with parsed timestamps
             call_kwargs = mock_client.events.list_events.call_args.kwargs

--- a/tests/commands/test_metric.py
+++ b/tests/commands/test_metric.py
@@ -7,6 +7,23 @@ from click.testing import CliRunner
 from ddogctl.commands.metric import metric
 
 
+class MockPoint:
+    """Mock SDK Point object — wraps [timestamp, value] in a .value attribute."""
+
+    def __init__(self, timestamp, value):
+        self._data = [timestamp, value]
+
+    @property
+    def value(self):
+        return self._data
+
+    def __iter__(self):
+        raise TypeError("MockPoint does not support iteration (like the real SDK Point)")
+
+    def __getitem__(self, key):
+        raise TypeError("MockPoint does not support subscript access")
+
+
 class MockMetricQueryResponse:
     """Mock Datadog metric query response."""
 
@@ -89,8 +106,8 @@ def test_metric_query_csv_format(mock_client, runner):
             {
                 "metric": "database.connections",
                 "pointlist": [
-                    [1609459200000, 150.0],
-                    [1609459260000, 155.0],
+                    MockPoint(1609459200000, 150.0),
+                    MockPoint(1609459260000, 155.0),
                 ],
             }
         ]
@@ -119,7 +136,7 @@ def test_metric_query_table_format(mock_client, runner):
         series=[
             {
                 "metric": "trace.web.request",
-                "pointlist": [[1609459200000, 123.45]],
+                "pointlist": [MockPoint(1609459200000, 123.45)],
             }
         ]
     )
@@ -359,7 +376,7 @@ def test_metric_query_multiple_series(mock_client, runner):
 def test_metric_query_table_format_truncates_points(mock_client, runner):
     """Test that table format shows only last 20 points."""
     # Create 30 data points
-    pointlist = [[1609459200000 + (i * 60000), 50.0 + i] for i in range(30)]
+    pointlist = [MockPoint(1609459200000 + (i * 60000), 50.0 + i) for i in range(30)]
 
     mock_response = MockMetricQueryResponse(
         series=[


### PR DESCRIPTION
## Summary

Fixes #44 — three bugs found during a production incident investigation:

- **metric query crash**: `Point` objects from the SDK don't support iteration/subscript. Fixed by accessing `point.value` to unpack `[timestamp, value]`
- **dbm queries crash**: `DatadogClient` was missing a `dbm` attribute. Added `DBMClient` wrapper that makes direct HTTP calls to `/api/v2/dbm/*` endpoints
- **event list --from**: Replaced non-standard `--since` flag with `--from`/`--to` for consistency with all other time-based commands

Also bumps version to 2.0.3.

## Test plan

- [x] Updated metric tests with `MockPoint` that mimics real SDK behavior (no iteration support)
- [x] Updated event tests to use `--from`/`--to` flags
- [x] All 679 tests pass
- [x] black, ruff, mypy clean (no new errors)