### PR TITLE
fix(dbm): swap call_api arg order to fix host resolution error

### DIFF
--- a/ddogctl/client.py
+++ b/ddogctl/client.py
@@ -54,7 +54,10 @@ class DBMClient:
         """Make a direct REST call through the SDK's ApiClient."""
         params = {k: v for k, v in query_params.items() if v is not None}
         response = self._api_client.call_api(
-            method, path, query_params=params, header_params={"Accept": "application/json"}
+            resource_path=path,
+            method=method,
+            query_params=params,
+            header_params={"Accept": "application/json"},
         )
         import json
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -357,3 +357,29 @@ class TestClientConfiguration:
         DatadogClient(config)
 
         assert mock_config_instance.server_variables["site"] == expected_site
+
+
+class TestDBMClient:
+    """Tests for DBMClient direct HTTP call wrapper."""
+
+    def test_call_api_arg_order_resource_path_before_method(self):
+        """Verify call_api receives (resource_path, method), not (method, resource_path).
+
+        Regression test for #46: reversed arg order caused the HTTP method to be
+        concatenated to the hostname (e.g. api.datadoghq.comget).
+        """
+        import json as json_mod
+
+        mock_api_client = Mock()
+        mock_api_client.call_api.return_value = Mock(
+            response=Mock(data=json_mod.dumps({"data": []}).encode())
+        )
+
+        from ddogctl.client import DBMClient
+
+        client = DBMClient(mock_api_client)
+        client.list_hosts()
+
+        call_kwargs = mock_api_client.call_api.call_args.kwargs
+        assert call_kwargs["resource_path"] == "/api/v2/dbm/hosts"
+        assert call_kwargs["method"] == "GET"


### PR DESCRIPTION
## Summary

Fixes #46.

- `DBMClient._call()` was passing `(method, path)` to the SDK's `call_api()`, but it expects `(resource_path, method)` — causing the HTTP method to be concatenated to the hostname (e.g. `api.datadoghq.comget`)
- Switched to explicit keyword arguments (`resource_path=path, method=method`) to prevent future arg order confusion
- Added regression test verifying correct argument names

## Test plan

- [x] Regression test `test_call_api_arg_order_resource_path_before_method` passes
- [x] Full test suite (680 tests) passes
- [x] Lint and format checks pass