### PR TITLE
chore: release 2.0.4 with dbm fix (closes #50)

### DIFF
--- a/ddogctl/cli.py
+++ b/ddogctl/cli.py
@@ -36,7 +36,7 @@ class AliasGroup(click.Group):
 
 
 @click.group(cls=AliasGroup)
-@click.version_option(version="2.0.3")
+@click.version_option(version="2.0.4")
 @click.option(
     "--profile",
     default=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ddogctl"
-version = "2.0.3"
+version = "2.0.4"
 description = "A modern CLI for the Datadog API. Like Dogshell, but better."
 authors = [{name = "Sergio Francisco", email = "email@sergiofrancisco.com"}]
 license = "MIT"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -362,24 +362,59 @@ class TestClientConfiguration:
 class TestDBMClient:
     """Tests for DBMClient direct HTTP call wrapper."""
 
-    def test_call_api_arg_order_resource_path_before_method(self):
-        """Verify call_api receives (resource_path, method), not (method, resource_path).
-
-        Regression test for #46: reversed arg order caused the HTTP method to be
-        concatenated to the hostname (e.g. api.datadoghq.comget).
-        """
+    @staticmethod
+    def _mock_api_client():
         import json as json_mod
 
         mock_api_client = Mock()
         mock_api_client.call_api.return_value = Mock(
             response=Mock(data=json_mod.dumps({"data": []}).encode())
         )
+        return mock_api_client
 
+    def test_list_hosts_uses_keyword_args(self):
+        """Regression test for #46: reversed arg order caused the HTTP method to be
+        concatenated to the hostname (e.g. api.datadoghq.comget)."""
         from ddogctl.client import DBMClient
 
-        client = DBMClient(mock_api_client)
-        client.list_hosts()
+        mock_api_client = self._mock_api_client()
+        DBMClient(mock_api_client).list_hosts()
 
         call_kwargs = mock_api_client.call_api.call_args.kwargs
         assert call_kwargs["resource_path"] == "/api/v2/dbm/hosts"
+        assert call_kwargs["method"] == "GET"
+
+    def test_list_queries_uses_keyword_args(self):
+        """Regression test for #50: dbm queries failed with malformed host
+        api.datadoghq.comget when call_api received positional args."""
+        from ddogctl.client import DBMClient
+
+        mock_api_client = self._mock_api_client()
+        DBMClient(mock_api_client).list_queries(from_ts=1, to_ts=2, limit=5)
+
+        call_kwargs = mock_api_client.call_api.call_args.kwargs
+        assert call_kwargs["resource_path"] == "/api/v2/dbm/activity"
+        assert call_kwargs["method"] == "GET"
+
+    def test_list_query_samples_uses_keyword_args(self):
+        """Regression test for #50: dbm samples failed with malformed host
+        api.datadoghq.comget when call_api received positional args."""
+        from ddogctl.client import DBMClient
+
+        mock_api_client = self._mock_api_client()
+        DBMClient(mock_api_client).list_query_samples("abc123", from_ts=1, to_ts=2, limit=1)
+
+        call_kwargs = mock_api_client.call_api.call_args.kwargs
+        assert call_kwargs["resource_path"] == "/api/v2/dbm/query/abc123/samples"
+        assert call_kwargs["method"] == "GET"
+
+    def test_get_query_plan_uses_keyword_args(self):
+        """All DBMClient methods funnel through _call, so verify the explain path too."""
+        from ddogctl.client import DBMClient
+
+        mock_api_client = self._mock_api_client()
+        DBMClient(mock_api_client).get_query_plan("abc123")
+
+        call_kwargs = mock_api_client.call_api.call_args.kwargs
+        assert call_kwargs["resource_path"] == "/api/v2/dbm/query/abc123/plan"
         assert call_kwargs["method"] == "GET"

--- a/uv.lock
+++ b/uv.lock
@@ -309,7 +309,7 @@ wheels = [
 
 [[package]]
 name = "ddogctl"
-version = "2.0.0"
+version = "2.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bumps version to 2.0.4 in `pyproject.toml` and `ddogctl/cli.py` so the dbm fix from #46/#47 (commit 07d0ec4) lands on PyPI. The user in #50 is on 2.0.3, which predates that fix — that's why the bug is still being reported.
- Extends `TestDBMClient` to cover `list_queries`, `list_query_samples`, and `get_query_plan`, in addition to `list_hosts`. The original regression test only exercised `list_hosts`, but the issue specifically reports `dbm queries` and `dbm samples`, so worth pinning those paths explicitly.

Closes #50

## Test plan
- [x] `uv run pytest tests/ -q` (683 passed)
- [x] `uv run black ddogctl/ tests/`
- [x] `uv run ruff check ddogctl/ tests/`
- [ ] After merge: tag `v2.0.4` to trigger PyPI publish per `CLAUDE.md` releasing flow.