### PR TITLE
fix(logs): serialize time-range timestamps in UTC (#52)

### DIFF
--- a/ddogctl/commands/apm.py
+++ b/ddogctl/commands/apm.py
@@ -2,12 +2,11 @@
 
 import click
 import json
-from datetime import datetime
 from rich.console import Console
 from rich.table import Table
 from ddogctl.client import get_datadog_client
 from ddogctl.utils.error import handle_api_error
-from ddogctl.utils.time import parse_time_range
+from ddogctl.utils.time import parse_time_range, to_utc_iso
 from ddogctl.utils.spans import aggregate_spans
 
 console = Console()
@@ -77,8 +76,8 @@ def search_traces(service, from_time, to_time, limit, extra_filter, format):
 
     # Parse time range
     from_ts, to_ts = parse_time_range(from_time, to_time)
-    from_str = datetime.fromtimestamp(from_ts).isoformat() + "Z"
-    to_str = datetime.fromtimestamp(to_ts).isoformat() + "Z"
+    from_str = to_utc_iso(from_ts)
+    to_str = to_utc_iso(to_ts)
 
     # Build query
     query = f"service:{service}"
@@ -150,8 +149,8 @@ def analytics(service, from_time, to_time, metric, group_by, format):
 
     # Parse time range
     from_ts, to_ts = parse_time_range(from_time, to_time)
-    from_str = datetime.fromtimestamp(from_ts).isoformat() + "Z"
-    to_str = datetime.fromtimestamp(to_ts).isoformat() + "Z"
+    from_str = to_utc_iso(from_ts)
+    to_str = to_utc_iso(to_ts)
 
     # Build filter (as dict)
     filter_dict = {"query": f"service:{service}", "from": from_str, "to": to_str}

--- a/ddogctl/commands/ci.py
+++ b/ddogctl/commands/ci.py
@@ -2,12 +2,11 @@
 
 import click
 import json
-from datetime import datetime
 from rich.console import Console
 from rich.table import Table
 from ddogctl.client import get_datadog_client
 from ddogctl.utils.error import handle_api_error
-from ddogctl.utils.time import parse_time_range
+from ddogctl.utils.time import parse_time_range, to_utc_datetime
 
 console = Console()
 
@@ -63,8 +62,8 @@ def pipelines(query, from_time, to_time, limit, format):
     client = get_datadog_client()
 
     from_ts, to_ts = parse_time_range(from_time, to_time)
-    from_dt = datetime.fromtimestamp(from_ts)
-    to_dt = datetime.fromtimestamp(to_ts)
+    from_dt = to_utc_datetime(from_ts)
+    to_dt = to_utc_datetime(to_ts)
 
     with console.status("[cyan]Searching CI pipeline events...[/cyan]"):
         response = client.ci_pipelines.list_ci_app_pipeline_events(
@@ -136,8 +135,8 @@ def tests(query, from_time, to_time, limit, format):
     client = get_datadog_client()
 
     from_ts, to_ts = parse_time_range(from_time, to_time)
-    from_dt = datetime.fromtimestamp(from_ts)
-    to_dt = datetime.fromtimestamp(to_ts)
+    from_dt = to_utc_datetime(from_ts)
+    to_dt = to_utc_datetime(to_ts)
 
     with console.status("[cyan]Searching CI test events...[/cyan]"):
         response = client.ci_tests.list_ci_app_test_events(

--- a/ddogctl/commands/investigate.py
+++ b/ddogctl/commands/investigate.py
@@ -2,12 +2,11 @@
 
 import click
 import json
-from datetime import datetime
 from rich.console import Console
 from rich.table import Table
 from ddogctl.client import get_datadog_client
 from ddogctl.utils.error import handle_api_error
-from ddogctl.utils.time import parse_time_range
+from ddogctl.utils.time import parse_time_range, to_utc_iso
 from ddogctl.utils.spans import aggregate_spans
 
 console = Console()
@@ -30,8 +29,8 @@ def investigate_latency(service, from_time, to_time, threshold, fmt):
     """Investigate high latency issues for a service."""
     client = get_datadog_client()
     from_ts, to_ts = parse_time_range(from_time, to_time)
-    from_str = datetime.fromtimestamp(from_ts).isoformat() + "Z"
-    to_str = datetime.fromtimestamp(to_ts).isoformat() + "Z"
+    from_str = to_utc_iso(from_ts)
+    to_str = to_utc_iso(to_ts)
 
     threshold_ns = threshold * 1_000_000  # convert ms to ns
 
@@ -127,8 +126,8 @@ def investigate_errors(service, from_time, to_time, fmt):
     """Investigate error patterns for a service."""
     client = get_datadog_client()
     from_ts, to_ts = parse_time_range(from_time, to_time)
-    from_str = datetime.fromtimestamp(from_ts).isoformat() + "Z"
-    to_str = datetime.fromtimestamp(to_ts).isoformat() + "Z"
+    from_str = to_utc_iso(from_ts)
+    to_str = to_utc_iso(to_ts)
 
     with console.status(f"[cyan]Investigating errors for {service}...[/cyan]"):
         # Step 1: Count error traces
@@ -221,8 +220,8 @@ def investigate_throughput(service, from_time, to_time, fmt):
     """Investigate throughput for a service."""
     client = get_datadog_client()
     from_ts, to_ts = parse_time_range(from_time, to_time)
-    from_str = datetime.fromtimestamp(from_ts).isoformat() + "Z"
-    to_str = datetime.fromtimestamp(to_ts).isoformat() + "Z"
+    from_str = to_utc_iso(from_ts)
+    to_str = to_utc_iso(to_ts)
 
     with console.status(f"[cyan]Investigating throughput for {service}...[/cyan]"):
         # Step 1: Get total request count
@@ -292,14 +291,14 @@ def investigate_compare(service, from_time, baseline, fmt):
 
     # Current period: from_time ago to now
     current_from_ts, current_to_ts = parse_time_range(from_time, "now")
-    current_from_str = datetime.fromtimestamp(current_from_ts).isoformat() + "Z"
-    current_to_str = datetime.fromtimestamp(current_to_ts).isoformat() + "Z"
+    current_from_str = to_utc_iso(current_from_ts)
+    current_to_str = to_utc_iso(current_to_ts)
 
     # Baseline period: baseline ago to from_time ago
     baseline_from_ts, _ = parse_time_range(baseline, "now")
     baseline_to_ts = current_from_ts
-    baseline_from_str = datetime.fromtimestamp(baseline_from_ts).isoformat() + "Z"
-    baseline_to_str = datetime.fromtimestamp(baseline_to_ts).isoformat() + "Z"
+    baseline_from_str = to_utc_iso(baseline_from_ts)
+    baseline_to_str = to_utc_iso(baseline_to_ts)
 
     with console.status(f"[cyan]Comparing metrics for {service}...[/cyan]"):
         # Current period: count

--- a/ddogctl/commands/logs.py
+++ b/ddogctl/commands/logs.py
@@ -3,12 +3,11 @@
 import click
 import json
 import time
-from datetime import datetime
 from rich.console import Console
 from rich.table import Table
 from ddogctl.client import get_datadog_client
 from ddogctl.utils.error import handle_api_error
-from ddogctl.utils.time import parse_time_range
+from ddogctl.utils.time import parse_time_range, to_utc_iso
 
 console = Console()
 
@@ -95,8 +94,8 @@ def search_logs(query, from_time, to_time, service, status, limit, format):
 
     # Parse time range
     from_ts, to_ts = parse_time_range(from_time, to_time)
-    from_str = datetime.fromtimestamp(from_ts).isoformat() + "Z"
-    to_str = datetime.fromtimestamp(to_ts).isoformat() + "Z"
+    from_str = to_utc_iso(from_ts)
+    to_str = to_utc_iso(to_ts)
 
     # Build query with optional filters
     full_query = query
@@ -154,8 +153,8 @@ def tail_logs(query, lines, service, follow, format):
     def fetch_logs():
         """Fetch recent logs from the API."""
         from_ts, to_ts = parse_time_range("15m", "now")
-        from_str = datetime.fromtimestamp(from_ts).isoformat() + "Z"
-        to_str = datetime.fromtimestamp(to_ts).isoformat() + "Z"
+        from_str = to_utc_iso(from_ts)
+        to_str = to_utc_iso(to_ts)
 
         body = {
             "filter": {
@@ -256,8 +255,8 @@ def query_logs(query, from_time, to_time, group_by, metric, format):
 
     # Parse time range
     from_ts, to_ts = parse_time_range(from_time, to_time)
-    from_str = datetime.fromtimestamp(from_ts).isoformat() + "Z"
-    to_str = datetime.fromtimestamp(to_ts).isoformat() + "Z"
+    from_str = to_utc_iso(from_ts)
+    to_str = to_utc_iso(to_ts)
 
     # Build filter
     filter_dict = {

--- a/ddogctl/commands/rum.py
+++ b/ddogctl/commands/rum.py
@@ -2,12 +2,11 @@
 
 import click
 import json
-from datetime import datetime
 from rich.console import Console
 from rich.table import Table
 from ddogctl.client import get_datadog_client
 from ddogctl.utils.error import handle_api_error
-from ddogctl.utils.time import parse_time_range
+from ddogctl.utils.time import parse_time_range, to_utc_iso
 
 console = Console()
 
@@ -54,8 +53,8 @@ def list_events(query, from_time, to_time, limit, format):
 
     # Parse time range
     from_ts, to_ts = parse_time_range(from_time, to_time)
-    from_str = datetime.fromtimestamp(from_ts).isoformat() + "Z"
-    to_str = datetime.fromtimestamp(to_ts).isoformat() + "Z"
+    from_str = to_utc_iso(from_ts)
+    to_str = to_utc_iso(to_ts)
 
     with console.status("[cyan]Searching RUM events...[/cyan]"):
         response = client.rum.list_rum_events(
@@ -123,8 +122,8 @@ def analytics(query, metric, group_by, from_time, to_time, format):
 
     # Parse time range
     from_ts, to_ts = parse_time_range(from_time, to_time)
-    from_str = datetime.fromtimestamp(from_ts).isoformat() + "Z"
-    to_str = datetime.fromtimestamp(to_ts).isoformat() + "Z"
+    from_str = to_utc_iso(from_ts)
+    to_str = to_utc_iso(to_ts)
 
     # Build filter
     filter_dict = {"query": query, "from": from_str, "to": to_str}

--- a/ddogctl/utils/time.py
+++ b/ddogctl/utils/time.py
@@ -1,6 +1,6 @@
 """Time parsing utilities."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import re
 
 
@@ -12,18 +12,17 @@ def parse_time_range(from_str: str, to_str: str = "now") -> tuple[int, int]:
     - "1h" (1 hour ago)
     - "24h" (24 hours ago)
     - "7d" (7 days ago)
-    - "2026-02-10T10:00:00" (ISO datetime)
+    - "2026-02-10T10:00:00" (ISO datetime; naive values are treated as UTC)
 
     Returns:
-        Tuple of (from_timestamp, to_timestamp)
+        Tuple of (from_timestamp, to_timestamp) as integer Unix epochs.
     """
-    now = datetime.now()
+    now = datetime.now(timezone.utc)
 
     def parse_relative(s: str) -> datetime:
         if s == "now":
             return now
 
-        # Match patterns like "1h", "24h", "7d", "30m"
         match = re.match(r"^(\d+)([hdm])$", s)
         if match:
             value = int(match.group(1))
@@ -36,13 +35,39 @@ def parse_time_range(from_str: str, to_str: str = "now") -> tuple[int, int]:
             elif unit == "m":
                 return now - timedelta(minutes=value)
 
-        # Try parsing as ISO datetime
         try:
-            return datetime.fromisoformat(s)
+            dt = datetime.fromisoformat(s)
         except ValueError:
             raise ValueError(f"Invalid time format: {s}")
+
+        # Treat naive ISO strings as UTC rather than local — matches the
+        # rest of the CLI, which always talks to Datadog in UTC.
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
 
     from_dt = parse_relative(from_str)
     to_dt = parse_relative(to_str)
 
     return int(from_dt.timestamp()), int(to_dt.timestamp())
+
+
+def to_utc_iso(ts: int) -> str:
+    """Convert a Unix timestamp to a UTC ISO-8601 string (``YYYY-MM-DDTHH:MM:SSZ``).
+
+    Datadog's Logs/APM/RUM search APIs accept ISO-8601 timestamps and assume the
+    ``Z`` suffix means UTC. Callers must therefore format the epoch in UTC; using
+    naive ``datetime.fromtimestamp`` produces *local* time and then mislabels it as
+    UTC, silently shifting every query by the local UTC offset (issue #52).
+    """
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def to_utc_datetime(ts: int) -> datetime:
+    """Convert a Unix timestamp to a UTC-aware datetime.
+
+    Use this when handing a value to the Datadog SDK as a ``datetime`` (e.g. the
+    CI Visibility client takes ``filter_from``/``filter_to`` as datetimes). A
+    naive datetime would be serialized by the SDK in local time.
+    """
+    return datetime.fromtimestamp(ts, tz=timezone.utc)

--- a/tests/commands/test_logs.py
+++ b/tests/commands/test_logs.py
@@ -1,8 +1,14 @@
 """Tests for Logs commands."""
 
 import json
-from datetime import datetime
+import os
+import re
+import time
+from datetime import datetime, timezone
 from unittest.mock import Mock, patch
+
+import pytest
+
 from tests.conftest import create_mock_log
 
 # Search command tests
@@ -833,3 +839,93 @@ def test_logs_tail_missing_attributes(mock_client, runner):
         assert result.exit_code == 0
         output = json.loads(result.output)
         assert len(output) == 1
+
+
+# Regression tests for issue #52: timestamps must be serialized as UTC ISO
+# strings regardless of the host TZ. Previously the code labeled local time
+# with a "Z" suffix, silently shifting every query by the local UTC offset.
+
+
+ISO_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+
+@pytest.fixture
+def _non_utc_tz():
+    """Run the test as if the process TZ were America/Sao_Paulo (UTC-3)."""
+    original = os.environ.get("TZ")
+    os.environ["TZ"] = "America/Sao_Paulo"
+    time.tzset()
+    try:
+        yield
+    finally:
+        if original is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = original
+        time.tzset()
+
+
+def _assert_window_is_utc_now(body, expected_window_seconds, tolerance_seconds=5):
+    """Assert filter.from/to are UTC ISO strings spanning the expected window."""
+    from_str = body["filter"]["from"]
+    to_str = body["filter"]["to"]
+
+    assert ISO_UTC_RE.match(from_str), f"from is not a UTC ISO string: {from_str!r}"
+    assert ISO_UTC_RE.match(to_str), f"to is not a UTC ISO string: {to_str!r}"
+
+    from_dt = datetime.strptime(from_str, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    to_dt = datetime.strptime(to_str, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+
+    # ``to`` is "now" — within a few seconds of UTC wall clock.
+    assert (
+        abs((now - to_dt).total_seconds()) <= tolerance_seconds
+    ), f"'to' {to_dt} is not close to UTC now {now}"
+
+    # Window length is the expected number of seconds.
+    window = (to_dt - from_dt).total_seconds()
+    assert (
+        abs(window - expected_window_seconds) <= tolerance_seconds
+    ), f"window {window}s != expected {expected_window_seconds}s"
+
+
+def test_logs_search_uses_utc_iso_under_non_utc_tz(mock_client, runner, _non_utc_tz):
+    """Regression for #52: --from 5m must produce a UTC window, not local-time-as-Z."""
+    from ddogctl.commands.logs import logs
+
+    mock_client.logs.list_logs.return_value = Mock(data=[], meta=Mock(page=Mock(after=None)))
+
+    with patch("ddogctl.commands.logs.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(logs, ["search", "*", "--from", "5m"])
+
+    assert result.exit_code == 0
+    body = mock_client.logs.list_logs.call_args.kwargs["body"]
+    _assert_window_is_utc_now(body, expected_window_seconds=5 * 60)
+
+
+def test_logs_tail_uses_utc_iso_under_non_utc_tz(mock_client, runner, _non_utc_tz):
+    """Regression for #52: tail's 15m window must be in UTC."""
+    from ddogctl.commands.logs import logs
+
+    mock_client.logs.list_logs.return_value = Mock(data=[], meta=Mock(page=Mock(after=None)))
+
+    with patch("ddogctl.commands.logs.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(logs, ["tail", "*"])
+
+    assert result.exit_code == 0
+    body = mock_client.logs.list_logs.call_args.kwargs["body"]
+    _assert_window_is_utc_now(body, expected_window_seconds=15 * 60)
+
+
+def test_logs_query_uses_utc_iso_under_non_utc_tz(mock_client, runner, _non_utc_tz):
+    """Regression for #52: log analytics path must also serialize UTC."""
+    from ddogctl.commands.logs import logs
+
+    mock_client.logs.aggregate_logs.return_value = Mock(data=Mock(buckets=[]))
+
+    with patch("ddogctl.commands.logs.get_datadog_client", return_value=mock_client):
+        result = runner.invoke(logs, ["query", "--query", "*", "--from", "1h"])
+
+    assert result.exit_code == 0
+    body = mock_client.logs.aggregate_logs.call_args.kwargs["body"]
+    _assert_window_is_utc_now(body, expected_window_seconds=60 * 60)

--- a/tests/utils/test_time.py
+++ b/tests/utils/test_time.py
@@ -1,9 +1,12 @@
 """Tests for time parsing utilities."""
 
+import os
+import time
 import pytest
 from unittest.mock import patch
-from datetime import datetime, timedelta
-from ddogctl.utils.time import parse_time_range
+from datetime import datetime, timedelta, timezone
+
+from ddogctl.utils.time import parse_time_range, to_utc_iso, to_utc_datetime
 
 
 class TestParseTimeRange:
@@ -11,11 +14,10 @@ class TestParseTimeRange:
 
     @pytest.fixture
     def mock_now(self):
-        """Fixed datetime for predictable testing."""
-        return datetime(2026, 2, 11, 15, 30, 0)  # 2026-02-11 15:30:00
+        """Fixed UTC datetime for predictable testing."""
+        return datetime(2026, 2, 11, 15, 30, 0, tzinfo=timezone.utc)
 
     def test_now_to_now(self, mock_now):
-        """Test 'now' to 'now' returns same timestamp."""
         with patch("ddogctl.utils.time.datetime") as mock_datetime:
             mock_datetime.now.return_value = mock_now
             from_ts, to_ts = parse_time_range("now", "now")
@@ -24,193 +26,176 @@ class TestParseTimeRange:
             assert from_ts == int(mock_now.timestamp())
 
     def test_hours_ago(self, mock_now):
-        """Test relative hour parsing (1h, 24h, etc.)."""
         with patch("ddogctl.utils.time.datetime") as mock_datetime:
             mock_datetime.now.return_value = mock_now
 
-            # 1 hour ago
             from_ts, to_ts = parse_time_range("1h", "now")
-            expected_from = mock_now - timedelta(hours=1)
-            assert from_ts == int(expected_from.timestamp())
+            assert from_ts == int((mock_now - timedelta(hours=1)).timestamp())
             assert to_ts == int(mock_now.timestamp())
 
-            # 24 hours ago
-            from_ts, to_ts = parse_time_range("24h", "now")
-            expected_from = mock_now - timedelta(hours=24)
-            assert from_ts == int(expected_from.timestamp())
+            from_ts, _ = parse_time_range("24h", "now")
+            assert from_ts == int((mock_now - timedelta(hours=24)).timestamp())
 
     def test_days_ago(self, mock_now):
-        """Test relative day parsing (1d, 7d, etc.)."""
         with patch("ddogctl.utils.time.datetime") as mock_datetime:
             mock_datetime.now.return_value = mock_now
 
-            # 7 days ago
             from_ts, to_ts = parse_time_range("7d", "now")
-            expected_from = mock_now - timedelta(days=7)
-            assert from_ts == int(expected_from.timestamp())
+            assert from_ts == int((mock_now - timedelta(days=7)).timestamp())
             assert to_ts == int(mock_now.timestamp())
 
     def test_minutes_ago(self, mock_now):
-        """Test relative minute parsing (30m, 60m, etc.)."""
         with patch("ddogctl.utils.time.datetime") as mock_datetime:
             mock_datetime.now.return_value = mock_now
 
-            # 30 minutes ago
             from_ts, to_ts = parse_time_range("30m", "now")
-            expected_from = mock_now - timedelta(minutes=30)
-            assert from_ts == int(expected_from.timestamp())
+            assert from_ts == int((mock_now - timedelta(minutes=30)).timestamp())
             assert to_ts == int(mock_now.timestamp())
 
-    def test_iso_datetime_parsing(self, mock_now):
-        """Test ISO datetime format parsing."""
-        with patch("ddogctl.utils.time.datetime") as mock_datetime:
-            mock_datetime.now.return_value = mock_now
-            # Need to patch fromisoformat to work correctly
-            mock_datetime.fromisoformat = datetime.fromisoformat
-
-            # Specific ISO timestamp
-            iso_from = "2026-02-10T10:00:00"
-            iso_to = "2026-02-11T10:00:00"
-
-            from_ts, to_ts = parse_time_range(iso_from, iso_to)
-
-            expected_from = datetime.fromisoformat(iso_from)
-            expected_to = datetime.fromisoformat(iso_to)
-
-            assert from_ts == int(expected_from.timestamp())
-            assert to_ts == int(expected_to.timestamp())
-
-    def test_mixed_formats(self, mock_now):
-        """Test mixing relative and ISO formats."""
+    def test_iso_datetime_with_tz(self, mock_now):
+        """Aware ISO strings should be honored as-is."""
         with patch("ddogctl.utils.time.datetime") as mock_datetime:
             mock_datetime.now.return_value = mock_now
             mock_datetime.fromisoformat = datetime.fromisoformat
 
-            # From ISO to now
-            iso_from = "2026-02-10T10:00:00"
-            from_ts, to_ts = parse_time_range(iso_from, "now")
+            from_ts, to_ts = parse_time_range(
+                "2026-02-10T10:00:00+00:00",
+                "2026-02-11T10:00:00+00:00",
+            )
 
-            expected_from = datetime.fromisoformat(iso_from)
-            assert from_ts == int(expected_from.timestamp())
-            assert to_ts == int(mock_now.timestamp())
+            assert from_ts == int(datetime(2026, 2, 10, 10, 0, 0, tzinfo=timezone.utc).timestamp())
+            assert to_ts == int(datetime(2026, 2, 11, 10, 0, 0, tzinfo=timezone.utc).timestamp())
 
-            # From relative to ISO
-            iso_to = "2026-02-11T10:00:00"
-            from_ts, to_ts = parse_time_range("1h", iso_to)
+    def test_naive_iso_datetime_treated_as_utc(self, mock_now, monkeypatch):
+        """Regression: a naive ISO string must be treated as UTC, not local time."""
+        monkeypatch.setenv("TZ", "America/Sao_Paulo")
+        time.tzset()
+        try:
+            with patch("ddogctl.utils.time.datetime") as mock_datetime:
+                mock_datetime.now.return_value = mock_now
+                mock_datetime.fromisoformat = datetime.fromisoformat
 
-            expected_from = mock_now - timedelta(hours=1)
-            expected_to = datetime.fromisoformat(iso_to)
-            assert from_ts == int(expected_from.timestamp())
-            assert to_ts == int(expected_to.timestamp())
+                from_ts, _ = parse_time_range("2026-02-10T10:00:00", "now")
+
+                # Expected: 10:00 UTC, not 10:00 BRT (which would be 13:00 UTC).
+                assert from_ts == int(
+                    datetime(2026, 2, 10, 10, 0, 0, tzinfo=timezone.utc).timestamp()
+                )
+        finally:
+            monkeypatch.delenv("TZ", raising=False)
+            time.tzset()
 
     def test_default_to_parameter(self, mock_now):
-        """Test that 'to' parameter defaults to 'now'."""
         with patch("ddogctl.utils.time.datetime") as mock_datetime:
             mock_datetime.now.return_value = mock_now
 
-            # Only provide 'from', 'to' should default to 'now'
             from_ts, to_ts = parse_time_range("1h")
 
-            expected_from = mock_now - timedelta(hours=1)
-            assert from_ts == int(expected_from.timestamp())
+            assert from_ts == int((mock_now - timedelta(hours=1)).timestamp())
             assert to_ts == int(mock_now.timestamp())
 
-    def test_large_time_values(self, mock_now):
-        """Test edge cases with large time values."""
-        with patch("ddogctl.utils.time.datetime") as mock_datetime:
-            mock_datetime.now.return_value = mock_now
+    def test_now_is_utc_aware_in_real_call(self):
+        """Without mocks, parse_time_range should compute against a UTC clock.
 
-            # 365 days (1 year)
-            from_ts, to_ts = parse_time_range("365d", "now")
-            expected_from = mock_now - timedelta(days=365)
-            assert from_ts == int(expected_from.timestamp())
+        Regression for #52: previously used the naive ``datetime.now()`` which
+        only worked by accident in non-UTC timezones.
+        """
+        before = int(datetime.now(timezone.utc).timestamp())
+        _, to_ts = parse_time_range("1h", "now")
+        after = int(datetime.now(timezone.utc).timestamp())
 
-            # 8760 hours (1 year)
-            from_ts, to_ts = parse_time_range("8760h", "now")
-            expected_from = mock_now - timedelta(hours=8760)
-            assert from_ts == int(expected_from.timestamp())
-
-    def test_zero_values(self, mock_now):
-        """Test edge case with zero time values."""
-        with patch("ddogctl.utils.time.datetime") as mock_datetime:
-            mock_datetime.now.return_value = mock_now
-
-            # 0 hours ago (equivalent to now)
-            from_ts, to_ts = parse_time_range("0h", "now")
-            assert from_ts == int(mock_now.timestamp())
-            assert to_ts == int(mock_now.timestamp())
+        assert before - 1 <= to_ts <= after + 1
 
     def test_invalid_format_raises_error(self):
-        """Test that invalid formats raise ValueError."""
-        # Invalid unit
         with pytest.raises(ValueError, match="Invalid time format"):
-            parse_time_range("1y")  # 'y' for year not supported
-
-        # Invalid pattern
+            parse_time_range("1y")
         with pytest.raises(ValueError, match="Invalid time format"):
             parse_time_range("abc")
-
-        # Missing unit
         with pytest.raises(ValueError, match="Invalid time format"):
             parse_time_range("10")
-
-        # Invalid ISO format
         with pytest.raises(ValueError, match="Invalid time format"):
             parse_time_range("2026-99-99")
 
     def test_malformed_relative_time(self):
-        """Test various malformed relative time strings."""
-        invalid_inputs = [
-            "h1",  # Wrong order
-            "1",  # Missing unit
-            "1hh",  # Double unit
-            "-1h",  # Negative (not supported in regex)
-            "1.5h",  # Decimal (not supported in regex)
-            "1 h",  # Space not allowed
-        ]
-
-        for invalid_input in invalid_inputs:
+        for invalid in ["h1", "1", "1hh", "-1h", "1.5h", "1 h"]:
             with pytest.raises(ValueError, match="Invalid time format"):
-                parse_time_range(invalid_input)
-
-    def test_time_range_order(self, mock_now):
-        """Test that from_ts can be greater than to_ts (no validation enforced)."""
-        with patch("ddogctl.utils.time.datetime") as mock_datetime:
-            mock_datetime.now.return_value = mock_now
-
-            # 'from' is in the future relative to 'to' (now vs 1h ago)
-            # Function doesn't validate order, just parses
-            from_ts, to_ts = parse_time_range("now", "1h")
-
-            expected_from = mock_now
-            expected_to = mock_now - timedelta(hours=1)
-
-            assert from_ts == int(expected_from.timestamp())
-            assert to_ts == int(expected_to.timestamp())
-            # from_ts > to_ts in this case (no error raised)
-            assert from_ts > to_ts
+                parse_time_range(invalid)
 
     def test_timestamp_precision(self, mock_now):
-        """Test that timestamps are returned as integers (no fractional seconds)."""
         with patch("ddogctl.utils.time.datetime") as mock_datetime:
             mock_datetime.now.return_value = mock_now
-
             from_ts, to_ts = parse_time_range("1h", "now")
-
             assert isinstance(from_ts, int)
             assert isinstance(to_ts, int)
 
-    def test_multiple_digit_values(self, mock_now):
-        """Test parsing of multi-digit time values."""
-        with patch("ddogctl.utils.time.datetime") as mock_datetime:
-            mock_datetime.now.return_value = mock_now
 
-            # 100 hours
-            from_ts, to_ts = parse_time_range("100h", "now")
-            expected_from = mock_now - timedelta(hours=100)
-            assert from_ts == int(expected_from.timestamp())
+class TestToUtcIso:
+    """Test suite for the to_utc_iso helper (issue #52 fix)."""
 
-            # 999 days
-            from_ts, to_ts = parse_time_range("999d", "now")
-            expected_from = mock_now - timedelta(days=999)
-            assert from_ts == int(expected_from.timestamp())
+    def test_known_epoch_serializes_to_utc(self):
+        # 2026-05-12T22:05:00Z
+        ts = int(datetime(2026, 5, 12, 22, 5, 0, tzinfo=timezone.utc).timestamp())
+        assert to_utc_iso(ts) == "2026-05-12T22:05:00Z"
+
+    def test_non_utc_tz_does_not_shift_output(self, monkeypatch):
+        """Regression: output must be UTC regardless of the process TZ.
+
+        Before the fix, ``datetime.fromtimestamp(ts).isoformat() + "Z"`` would
+        emit local time mislabeled as UTC, silently shifting every Datadog
+        query by the local UTC offset.
+        """
+        ts = int(datetime(2026, 5, 12, 22, 5, 0, tzinfo=timezone.utc).timestamp())
+
+        for tz in ("America/Sao_Paulo", "Asia/Tokyo", "UTC"):
+            monkeypatch.setenv("TZ", tz)
+            time.tzset()
+            try:
+                assert to_utc_iso(ts) == "2026-05-12T22:05:00Z"
+            finally:
+                monkeypatch.delenv("TZ", raising=False)
+                time.tzset()
+
+    def test_format_is_seconds_precision_with_z_suffix(self):
+        ts = int(datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc).timestamp())
+        out = to_utc_iso(ts)
+        assert out.endswith("Z")
+        assert "." not in out  # no fractional seconds
+        assert "+" not in out  # no numeric offset
+
+
+class TestToUtcDatetime:
+    """Test suite for the to_utc_datetime helper."""
+
+    def test_returns_utc_aware_datetime(self):
+        ts = int(datetime(2026, 5, 12, 22, 5, 0, tzinfo=timezone.utc).timestamp())
+        dt = to_utc_datetime(ts)
+        assert dt.tzinfo is not None
+        assert dt.utcoffset() == timedelta(0)
+        assert dt.year == 2026
+        assert dt.month == 5
+        assert dt.day == 12
+        assert dt.hour == 22
+        assert dt.minute == 5
+
+    def test_non_utc_tz_does_not_shift_components(self, monkeypatch):
+        ts = int(datetime(2026, 5, 12, 22, 5, 0, tzinfo=timezone.utc).timestamp())
+        monkeypatch.setenv("TZ", "America/Sao_Paulo")
+        time.tzset()
+        try:
+            dt = to_utc_datetime(ts)
+            assert dt.hour == 22  # not 19
+        finally:
+            monkeypatch.delenv("TZ", raising=False)
+            time.tzset()
+
+
+@pytest.fixture(autouse=True)
+def _restore_tz():
+    """Always restore the original process TZ after every test."""
+    original = os.environ.get("TZ")
+    yield
+    if original is None:
+        os.environ.pop("TZ", None)
+    else:
+        os.environ["TZ"] = original
+    time.tzset()


### PR DESCRIPTION
## Summary

- Fixes #52. `datetime.fromtimestamp(ts).isoformat() + "Z"` converted the epoch to **naive local** time and then mislabeled it as UTC. On a host in a non-UTC timezone (e.g. BRT), every Datadog query was silently shifted by the local UTC offset — `--from 5m` returned data from ~3h05m to 3h ago.
- The anti-pattern existed at 12 call sites across `commands/logs.py` (3, as reported), `commands/apm.py` (2), `commands/rum.py` (2), `commands/investigate.py` (5), and `commands/ci.py` (2). Replaced them with two helpers in `utils/time.py`:
  - `to_utc_iso(ts)` → `"YYYY-MM-DDTHH:MM:SSZ"` for the Logs/APM/RUM search APIs that take ISO strings.
  - `to_utc_datetime(ts)` → UTC-aware `datetime` for CI Visibility SDK calls that take `datetime` objects.
- Also hardened `parse_time_range`: switched to `datetime.now(timezone.utc)` and now treats naive ISO input as UTC, matching how the CLI talks to Datadog.

## Test plan

- [x] `uv run pytest tests/ -m "not integration"` — 688 passed
- [x] `uv run black ddogctl/ tests/` — clean
- [x] `uv run ruff check ddogctl/ tests/` — clean
- [x] New unit tests for `to_utc_iso` / `to_utc_datetime` under `TZ=America/Sao_Paulo` and `Asia/Tokyo`
- [x] New regression tests that invoke `logs search`, `logs tail`, and `logs query` under a non-UTC TZ and assert the request body's `filter.from`/`filter.to` are correctly-labeled UTC ISO strings spanning the requested window
- [ ] Manual smoke: with the fix, `TZ=America/Sao_Paulo ddogctl logs search 'service:foo' --from 5m` now returns logs from the last 5 minutes instead of 3h5m–3h ago