### PR TITLE
chore: release 2.0.5

### DIFF
--- a/ddogctl/cli.py
+++ b/ddogctl/cli.py
@@ -36,7 +36,7 @@ class AliasGroup(click.Group):
 
 
 @click.group(cls=AliasGroup)
-@click.version_option(version="2.0.4")
+@click.version_option(version="2.0.5")
 @click.option(
     "--profile",
     default=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ddogctl"
-version = "2.0.4"
+version = "2.0.5"
 description = "A modern CLI for the Datadog API. Like Dogshell, but better."
 authors = [{name = "Sergio Francisco", email = "email@sergiofrancisco.com"}]
 license = "MIT"


### PR DESCRIPTION
## Summary

Patch release bundling the timezone fix.

- **#52 / #53** — fix(logs): serialize time-range timestamps in UTC, not local time

Before: on a host in a non-UTC timezone, `ddogctl logs search/tail/query` (and the same anti-pattern in apm/rum/investigate/ci) silently shifted every Datadog query by the local UTC offset.

## Test plan

- [x] `uv run pytest tests/ -m "not integration"` (688 passed)
- [ ] After merge, tag `v2.0.5` and push to trigger PyPI publish