### PR TITLE
fix(incident): read/write lifecycle via SDK 'state', not nonexistent 'status'

### DIFF
--- a/ddogctl/commands/incident.py
+++ b/ddogctl/commands/incident.py
@@ -43,7 +43,7 @@ def list_incidents(format):
                     "id": inc.id,
                     "title": getattr(attrs, "title", ""),
                     "severity": getattr(attrs, "severity", ""),
-                    "status": getattr(attrs, "status", ""),
+                    "status": getattr(attrs, "state", ""),
                     "created": str(getattr(attrs, "created", "")),
                     "modified": str(getattr(attrs, "modified", "")),
                 }
@@ -59,7 +59,7 @@ def list_incidents(format):
 
         for inc in incidents:
             attrs = inc.attributes
-            status_str = str(getattr(attrs, "status", ""))
+            status_str = str(getattr(attrs, "state", ""))
             severity_str = str(getattr(attrs, "severity", ""))
             status_color = {
                 "active": "red",
@@ -100,7 +100,7 @@ def get_incident(incident_id, format):
             "id": inc.id,
             "title": getattr(attrs, "title", ""),
             "severity": getattr(attrs, "severity", ""),
-            "status": getattr(attrs, "status", ""),
+            "status": getattr(attrs, "state", ""),
             "created": str(getattr(attrs, "created", "")),
             "modified": str(getattr(attrs, "modified", "")),
         }
@@ -112,7 +112,7 @@ def get_incident(incident_id, format):
         severity_str = str(getattr(attrs, "severity", ""))
         console.print(f"[bold]Severity:[/bold] [yellow]{severity_str}[/yellow]")
 
-        status_str = str(getattr(attrs, "status", ""))
+        status_str = str(getattr(attrs, "state", ""))
         status_color = {
             "active": "red",
             "stable": "yellow",
@@ -166,7 +166,7 @@ def create_incident(title, severity, format):
             "id": inc.id,
             "title": getattr(attrs, "title", ""),
             "severity": severity,
-            "status": getattr(attrs, "status", ""),
+            "status": getattr(attrs, "state", ""),
         }
         print(json.dumps(output, indent=2))
     else:
@@ -200,12 +200,12 @@ def update_incident(incident_id, title, status, severity, format):
     attrs_kwargs = {}
     if title is not None:
         attrs_kwargs["title"] = title
-    if status is not None:
-        attrs_kwargs["status"] = status
 
     fields = {}
     if severity is not None:
         fields["severity"] = {"type": "dropdown", "value": severity}
+    if status is not None:
+        fields["state"] = {"type": "dropdown", "value": status}
     if fields:
         attrs_kwargs["fields"] = fields
 
@@ -227,7 +227,7 @@ def update_incident(incident_id, title, status, severity, format):
         output = {
             "id": inc.id,
             "title": getattr(attrs, "title", ""),
-            "status": getattr(attrs, "status", ""),
+            "status": getattr(attrs, "state", ""),
         }
         print(json.dumps(output, indent=2))
     else:

--- a/tests/commands/test_incident.py
+++ b/tests/commands/test_incident.py
@@ -8,14 +8,20 @@ from ddogctl.commands.incident import incident
 def _make_incident(
     id, title, severity, status, created="2026-01-15T10:00:00Z", modified="2026-01-15T12:00:00Z"
 ):
-    """Create a mock incident object."""
+    """Create a mock incident object.
+
+    The Datadog v2 SDK exposes the incident lifecycle as ``state`` on
+    ``IncidentResponseAttributes`` — not ``status`` — so the mock uses
+    ``spec_set`` to reject the old attribute name and keep tests honest.
+    """
     inc = Mock()
     inc.id = id
     inc.type = "incidents"
     inc.attributes = Mock(
+        spec_set=["title", "severity", "state", "created", "modified", "fields"],
         title=title,
         severity=severity,
-        status=status,
+        state=status,
         created=created,
         modified=modified,
         fields={},
@@ -193,6 +199,47 @@ class TestUpdateIncident:
         result = runner.invoke(incident, ["update", "inc-1"])
         assert result.exit_code != 0
         assert "No update fields" in result.output
+
+    def test_update_incident_status_sent_as_fields_state(self, mock_client, runner):
+        """--status must be sent via fields["state"], not as a top-level attribute.
+
+        Regression test: the Datadog v2 SDK's ``IncidentUpdateAttributes`` has
+        no ``status`` (or ``state``) attribute — state changes flow through
+        the ``fields`` dict. Putting ``status`` on the attributes object
+        silently no-ops the lifecycle update.
+        """
+        inc = _make_incident("inc-1", "Service outage", "SEV-1", "resolved")
+        response = Mock(data=inc)
+        mock_client.incidents.update_incident.return_value = response
+
+        with patch("ddogctl.commands.incident.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(incident, ["update", "inc-1", "--status", "resolved"])
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        mock_client.incidents.update_incident.assert_called_once()
+        body = mock_client.incidents.update_incident.call_args.kwargs["body"]
+        attrs = body.data.attributes
+        state_field = attrs.fields["state"]
+        assert str(state_field["type"]) == "dropdown"
+        assert str(state_field["value"]) == "resolved"
+        assert not hasattr(attrs, "status")
+        assert not hasattr(attrs, "state")
+
+    def test_update_incident_json_reads_state(self, mock_client, runner):
+        """JSON output's ``status`` key must reflect the SDK's ``state`` attribute."""
+        inc = _make_incident("inc-1", "Service outage", "SEV-1", "resolved")
+        response = Mock(data=inc)
+        mock_client.incidents.update_incident.return_value = response
+
+        with patch("ddogctl.commands.incident.get_datadog_client", return_value=mock_client):
+            result = runner.invoke(
+                incident,
+                ["update", "inc-1", "--status", "resolved", "--format", "json"],
+            )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        output = json.loads(result.output)
+        assert output["status"] == "resolved"
 
 
 class TestDeleteIncident:


### PR DESCRIPTION
## Summary

The Datadog v2 SDK exposes the incident lifecycle as `state` on `IncidentResponseAttributes` — there is no `status` attribute. `getattr(attrs, "status", "")` therefore always returned an empty string against the real API, so `incident list`, `get`, `create`, and `update` all displayed empty status for every incident.

Likewise, `IncidentUpdateAttributes` has no `status` (or `state`) attribute — state changes must flow through `fields["state"]` as a `dropdown` (same pattern already used for `severity`). The previous code set `attrs_kwargs["status"] = status`, which was silently a no-op on the wire.

Verified directly against the installed SDK:

```
IncidentResponseAttributes  → has: state, severity, fields, title…  (no `status`)
IncidentUpdateAttributes    → has: fields, title…                   (no `status`/`state`)
```

## Why this slipped past tests

The existing fixtures built `Mock(status=...)`. `Mock` accepts any attribute name silently, so the wrong field name was never detected. This PR switches the fixture to `Mock(spec_set=[..., "state", ...])` so any future reversion will fail loudly.

## Changes

- `ddogctl/commands/incident.py`:
  - All reads: `getattr(attrs, "status", "")` → `getattr(attrs, "state", "")` (5 sites)
  - `update_incident`: route `--status` into `fields["state"] = {"type": "dropdown", "value": status}` instead of an attribute kwarg
- `tests/commands/test_incident.py`:
  - Fixture now uses `Mock(spec_set=[...])` with `state` (not `status`) so the mock matches the real SDK shape
  - New `test_update_incident_status_sent_as_fields_state` regression test asserting `--status` lands in `fields["state"]` on the request body, and that no `status`/`state` attribute is set on `IncidentUpdateAttributes`
  - New `test_update_incident_json_reads_state` verifying JSON output's `status` key sources from `attrs.state`

CLI-facing JSON output key stays `"status"` to match the existing `--status` flag.

## Context

This is the underlying bug that PR #48 (closed — hostile fork attempting a project-wide rebrand) was nominally pointing at. This PR fixes only that bug, scoped to two files.

## Test plan

- [x] `uv run pytest tests/commands/test_incident.py -v` → 17 passed
- [x] `uv run pytest tests/` → 690 passed
- [x] `uv run black --check ddogctl/ tests/` → clean
- [x] `uv run ruff check ddogctl/ tests/` → clean
- [ ] Smoke against a real Datadog tenant: `ddogctl incident list` shows non-empty status, and `ddogctl incident update <id> --status resolved` actually resolves the incident