### PR TITLE
feat(update): add `ddogctl update` to check PyPI for newer releases

### DIFF
--- a/ddogctl/cli.py
+++ b/ddogctl/cli.py
@@ -89,6 +89,7 @@ from ddogctl.commands.incident import incident
 from ddogctl.commands.user import user
 from ddogctl.commands.usage import usage
 from ddogctl.commands.ci import ci
+from ddogctl.commands.update import update
 
 main.add_command(monitor)
 main.add_command(metric)
@@ -114,6 +115,7 @@ main.add_command(incident)
 main.add_command(user)
 main.add_command(usage)
 main.add_command(ci)
+main.add_command(update)
 
 
 if __name__ == "__main__":

--- a/ddogctl/commands/update.py
+++ b/ddogctl/commands/update.py
@@ -1,0 +1,85 @@
+"""Check for newer ddogctl releases on PyPI."""
+
+import json
+import sys
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+import click
+import requests
+from packaging.version import InvalidVersion, Version
+from rich.console import Console
+
+PYPI_URL = "https://pypi.org/pypi/ddogctl/json"
+REQUEST_TIMEOUT = 5
+
+console = Console()
+
+
+def _current_version() -> str:
+    """Return the installed ddogctl version, or "0.0.0" if not installed."""
+    try:
+        return _pkg_version("ddogctl")
+    except PackageNotFoundError:
+        return "0.0.0"
+
+
+def _detect_upgrade_command(executable: str | None = None) -> str:
+    """Suggest the right upgrade command based on the running interpreter path."""
+    exe = executable if executable is not None else sys.executable
+    exe_lower = exe.lower()
+    if "pipx" in exe_lower:
+        return "pipx upgrade ddogctl"
+    if "/uv/tools/" in exe_lower or "\\uv\\tools\\" in exe_lower:
+        return "uv tool upgrade ddogctl"
+    return f"{exe} -m pip install --upgrade ddogctl"
+
+
+@click.command(name="update")
+@click.option("--format", "output_format", type=click.Choice(["json", "text"]), default="text")
+def update(output_format: str) -> None:
+    """Check PyPI for a newer ddogctl release.
+
+    Read-only: prints the upgrade command but does not install anything.
+    """
+    current = _current_version()
+    upgrade_cmd = _detect_upgrade_command()
+
+    try:
+        response = requests.get(PYPI_URL, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+        latest = response.json()["info"]["version"]
+    except requests.RequestException as exc:
+        message = f"Could not reach PyPI: {exc}"
+        if output_format == "json":
+            click.echo(json.dumps({"error": message, "current": current}))
+        else:
+            console.print(f"[red]{message}[/red]")
+        raise SystemExit(1)
+
+    try:
+        update_available = Version(latest) > Version(current)
+        local_ahead = Version(current) > Version(latest)
+    except InvalidVersion:
+        update_available = latest != current
+        local_ahead = False
+
+    if output_format == "json":
+        click.echo(
+            json.dumps(
+                {
+                    "current": current,
+                    "latest": latest,
+                    "update_available": update_available,
+                    "upgrade_command": upgrade_cmd,
+                }
+            )
+        )
+        return
+
+    if update_available:
+        console.print(f"[yellow]Update available:[/yellow] {current} -> [green]{latest}[/green]")
+        console.print(f"Run: [cyan]{upgrade_cmd}[/cyan]")
+    elif local_ahead:
+        console.print(f"[cyan]Local version {current} is ahead of PyPI ({latest}).[/cyan]")
+    else:
+        console.print(f"[green]ddogctl {current} is up to date.[/green]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "python-dotenv>=1.0.1",
     "requests>=2.32.3",
     "jinja2>=3.1.5",
+    "packaging>=23.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/commands/test_update.py
+++ b/tests/commands/test_update.py
@@ -1,0 +1,161 @@
+"""Tests for the update command."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from click.testing import CliRunner
+
+from ddogctl.cli import main
+
+
+def _mock_pypi_response(version: str) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"info": {"version": version}}
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+class TestUpdateCheck:
+    """Behaviour of `ddogctl update` (check-only)."""
+
+    def test_reports_up_to_date_when_versions_match(self):
+        runner = CliRunner()
+        with (
+            patch("ddogctl.commands.update.requests.get") as mock_get,
+            patch("ddogctl.commands.update._current_version", return_value="2.0.5"),
+        ):
+            mock_get.return_value = _mock_pypi_response("2.0.5")
+            result = runner.invoke(main, ["update"])
+
+        assert result.exit_code == 0
+        assert "up to date" in result.output.lower()
+        assert "2.0.5" in result.output
+
+    def test_reports_update_available_when_pypi_is_newer(self):
+        runner = CliRunner()
+        with (
+            patch("ddogctl.commands.update.requests.get") as mock_get,
+            patch("ddogctl.commands.update._current_version", return_value="2.0.5"),
+        ):
+            mock_get.return_value = _mock_pypi_response("2.1.0")
+            result = runner.invoke(main, ["update"])
+
+        assert result.exit_code == 0
+        assert "2.0.5" in result.output
+        assert "2.1.0" in result.output
+        # Should hint at an upgrade command
+        assert "install" in result.output.lower() or "upgrade" in result.output.lower()
+
+    def test_reports_ahead_when_local_is_newer(self):
+        runner = CliRunner()
+        with (
+            patch("ddogctl.commands.update.requests.get") as mock_get,
+            patch("ddogctl.commands.update._current_version", return_value="3.0.0"),
+        ):
+            mock_get.return_value = _mock_pypi_response("2.0.5")
+            result = runner.invoke(main, ["update"])
+
+        assert result.exit_code == 0
+        # Local is ahead — message should make that obvious
+        assert "ahead" in result.output.lower() or "newer" in result.output.lower()
+
+    def test_uses_pep440_version_comparison(self):
+        # 2.0.10 must be greater than 2.0.9 (not a lexical sort)
+        runner = CliRunner()
+        with (
+            patch("ddogctl.commands.update.requests.get") as mock_get,
+            patch("ddogctl.commands.update._current_version", return_value="2.0.9"),
+        ):
+            mock_get.return_value = _mock_pypi_response("2.0.10")
+            result = runner.invoke(main, ["update"])
+
+        assert result.exit_code == 0
+        assert "2.0.10" in result.output
+        assert "install" in result.output.lower() or "upgrade" in result.output.lower()
+
+
+class TestUpdateNetworkErrors:
+    """Network/HTTP error handling."""
+
+    def test_network_failure_exits_nonzero_with_message(self):
+        runner = CliRunner()
+        with (
+            patch("ddogctl.commands.update.requests.get") as mock_get,
+            patch("ddogctl.commands.update._current_version", return_value="2.0.5"),
+        ):
+            mock_get.side_effect = requests.ConnectionError("boom")
+            result = runner.invoke(main, ["update"])
+
+        assert result.exit_code != 0
+        assert "could not reach" in result.output.lower() or "failed" in result.output.lower()
+
+    def test_http_error_exits_nonzero(self):
+        runner = CliRunner()
+        with (
+            patch("ddogctl.commands.update.requests.get") as mock_get,
+            patch("ddogctl.commands.update._current_version", return_value="2.0.5"),
+        ):
+            err_resp = MagicMock()
+            err_resp.raise_for_status.side_effect = requests.HTTPError("500")
+            mock_get.return_value = err_resp
+            result = runner.invoke(main, ["update"])
+
+        assert result.exit_code != 0
+
+
+class TestUpdateJsonFormat:
+    """`--format json` output contract."""
+
+    def test_json_output_when_up_to_date(self):
+        runner = CliRunner()
+        with (
+            patch("ddogctl.commands.update.requests.get") as mock_get,
+            patch("ddogctl.commands.update._current_version", return_value="2.0.5"),
+        ):
+            mock_get.return_value = _mock_pypi_response("2.0.5")
+            result = runner.invoke(main, ["update", "--format", "json"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["current"] == "2.0.5"
+        assert payload["latest"] == "2.0.5"
+        assert payload["update_available"] is False
+        assert "upgrade_command" in payload
+
+    def test_json_output_when_update_available(self):
+        runner = CliRunner()
+        with (
+            patch("ddogctl.commands.update.requests.get") as mock_get,
+            patch("ddogctl.commands.update._current_version", return_value="2.0.5"),
+        ):
+            mock_get.return_value = _mock_pypi_response("2.1.0")
+            result = runner.invoke(main, ["update", "--format", "json"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["current"] == "2.0.5"
+        assert payload["latest"] == "2.1.0"
+        assert payload["update_available"] is True
+        assert payload["upgrade_command"]
+
+
+class TestInstallMethodDetection:
+    """Heuristic detection of install method."""
+
+    @pytest.mark.parametrize(
+        "executable,expected_substring",
+        [
+            ("/Users/x/.local/pipx/venvs/ddogctl/bin/python", "pipx"),
+            ("/Users/x/.local/share/uv/tools/ddogctl/bin/python", "uv tool"),
+            ("/Users/x/some/.venv/bin/python", "pip install --upgrade"),
+            ("/usr/local/bin/python3", "pip install --upgrade"),
+        ],
+    )
+    def test_detect_returns_appropriate_command(self, executable, expected_substring):
+        from ddogctl.commands.update import _detect_upgrade_command
+
+        cmd = _detect_upgrade_command(executable=executable)
+        assert expected_substring in cmd

--- a/uv.lock
+++ b/uv.lock
@@ -309,12 +309,13 @@ wheels = [
 
 [[package]]
 name = "ddogctl"
-version = "2.0.4"
+version = "2.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "datadog-api-client" },
     { name = "jinja2" },
+    { name = "packaging" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dateutil" },
@@ -340,6 +341,7 @@ requires-dist = [
     { name = "datadog-api-client", specifier = ">=2.29.0" },
     { name = "jinja2", specifier = ">=3.1.5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
+    { name = "packaging", specifier = ">=23.0" },
     { name = "pydantic", specifier = ">=2.10.5" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },


### PR DESCRIPTION
## Summary
- Add `ddogctl update` command that queries PyPI and reports whether a newer release is available — read-only, never installs.
- Compares versions with `packaging.version.Version` (PEP 440 ordering, so `2.0.10 > 2.0.9`).
- Detects install method from `sys.executable` and suggests the right upgrade command: `pipx upgrade`, `uv tool upgrade`, or `<python> -m pip install --upgrade`.
- Supports `--format json|text`.

## Test plan
- [x] `uv run pytest tests/commands/test_update.py -v` — 12 tests covering up-to-date, update-available, local-ahead, PEP 440 ordering, network/HTTP errors, JSON shape, and install-method detection
- [x] `uv run pytest tests/` — full suite (702 passed)
- [x] `uv run ruff check` and `uv run black` clean
- [x] Smoke test: `uv run ddogctl update` and `uv run ddogctl update --format json` against real PyPI