### PR TITLE
chore: release 2.1.0

### DIFF
--- a/ddogctl/cli.py
+++ b/ddogctl/cli.py
@@ -36,7 +36,7 @@ class AliasGroup(click.Group):
 
 
 @click.group(cls=AliasGroup)
-@click.version_option(version="2.0.5")
+@click.version_option(version="2.1.0")
 @click.option(
     "--profile",
     default=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ddogctl"
-version = "2.0.5"
+version = "2.1.0"
 description = "A modern CLI for the Datadog API. Like Dogshell, but better."
 authors = [{name = "Sergio Francisco", email = "email@sergiofrancisco.com"}]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version 2.0.5 → 2.1.0 for the `ddogctl update` PyPI checker (#57).

## Test plan
- [x] `pyproject.toml` and `ddogctl/cli.py` version strings match (`2.1.0`)
- [ ] CI green on Python 3.10–3.13
- [ ] After merge: tag `v2.1.0` to trigger PyPI publish workflow